### PR TITLE
Add hideLabel prop

### DIFF
--- a/src/forms/input.js
+++ b/src/forms/input.js
@@ -19,6 +19,7 @@ function Input ({
   input: { name, value, onBlur, onChange },
   meta: { error, touched, invalid },
   className,
+  hideLabel,
   hint,
   label,
   tooltip,
@@ -27,7 +28,9 @@ function Input ({
 }) {
   return (
     <fieldset className={ classes({ className, touched, invalid }) }>
-      <InputLabel { ...{ hint, label, name, tooltip } } />
+      { !hideLabel &&
+        <InputLabel { ...{ hint, label, name, tooltip } } />
+      }
       <input { ...{ id: name, name, type, value, onBlur, onChange, ...rest } }/>
       <InputError { ...{ error, invalid, touched } } />
     </fieldset>


### PR DESCRIPTION
Adds the ability to hide the input label based on `hideLabel` prop passed in. 

(This ended up being functionality we needed in InternX, and we just passed in an empty string to get around it.)

One question -- this feels like functionality we actually need in all input components (`Select`, `FileInput`, `Textarea`, `Checkbox`). Thoughts on creating a HOC that would handle that prop and potentially others? Or should I just add `hideLabel` to the other components as well?