### PR TITLE
Fix heroku build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",


### PR DESCRIPTION
Node-sass was giving us trouble - we have to force a rebuild using `yarn remove`.
https://github.com/yarnpkg/yarn/issues/1832

Also:
- Made `yarn run storybook:build` a heroku-specific script
- Made `sass` a dev dependency
- Removed prepublish linting
