### PR TITLE
Fix checkbox labels

### DIFF
--- a/src/forms/inputs/checkbox-group.js
+++ b/src/forms/inputs/checkbox-group.js
@@ -75,7 +75,7 @@ const defaultProps = {
 
 function CheckboxGroup (props) {
   const {
-    input: { value, onChange },
+    input: { value, onChange, name },
     meta, // eslint-disable-line no-unused-vars
     options,
     ...rest
@@ -98,7 +98,8 @@ function CheckboxGroup (props) {
               {...{
                 key: option.key,
                 input: {
-                  name: option.key,
+                  name: `${ name }.${ option.key }`,
+                  label: option.key,
                   value: value.includes(option.value),
                   onChange: handleChange(option)
                 },

--- a/src/forms/inputs/checkbox-group.js
+++ b/src/forms/inputs/checkbox-group.js
@@ -92,11 +92,11 @@ function CheckboxGroup (props) {
   return (
     <LabeledField className="CheckboxGroup" { ...props }>
       {
-        optionObjects.map((option) => {
+        optionObjects.map((option, i) => {
           return (
             <Checkbox
               {...{
-                key: option.key,
+                key: i,
                 input: {
                   name: `${ name }.${ option.key }`,
                   label: option.key,


### PR DESCRIPTION
This will resolve [ART-216](https://launchpadlab.atlassian.net/browse/ART-216).

The problem was that our `CheckboxGroup` inputs were creating checkboxes with the same ID's, confusing the HTML labels. I fixed this by namespacing nested checkboxes using the name of the parent `CheckboxGroup`.