### PR TITLE
Add ability to pass custom className to TabBar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/controls/tab-bar.js
+++ b/src/controls/tab-bar.js
@@ -33,6 +33,7 @@ const propTypes = {
   options: fieldOptionsType,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func,
+  className: PropTypes.string,
 }
 
 const defaultProps = {
@@ -40,21 +41,23 @@ const defaultProps = {
   options: [],
   value: '',
   onChange: noop,
+  className: '',
 }
 
-function TabBar ({ vertical, options, value, onChange }) {
+function TabBar ({ vertical, options, value, onChange, className }) {
   const optionObjects = objectify(options)
   const alignment = vertical ? 'vertical' : 'horizontal'
   return (
-    <ul className={`tabs ${alignment}-tabs`}>
+    <ul className={ classnames('tabs', `${alignment}-tabs`, className) }>
       {
         optionObjects.map(({ key, value: optionValue }) =>
           <li
-            className={classnames({ 'active': optionValue === value })}
-            key={key}
-            onClick={() => { onChange(optionValue) }}
+            className={ classnames({ 'active': optionValue === value }) }
+            key={ key }
           >
-          { key }
+            <a onClick={() => { onChange(optionValue) }}>
+              { key }
+            </a>
           </li>
         )
       }

--- a/test/controls/tab-bar.test.js
+++ b/test/controls/tab-bar.test.js
@@ -35,6 +35,11 @@ test('TabBar adds Active class', () => {
 test('TabBar calls onChange', () => {
   const onChange = jest.fn()
   const wrapper = mount(<TabBar options={objectOptions} onChange={ onChange } />)
-  wrapper.find('li').first().simulate('click')
+  wrapper.find('li > a').first().simulate('click')
   expect(onChange).toHaveBeenCalledWith('home')
+})
+
+test('TabBar passes down custom className to ul', () => {
+  const wrapper = mount(<TabBar className="custom" />)
+  expect(wrapper.find('ul').hasClass('custom')).toEqual(true)
 })


### PR DESCRIPTION
Important for styling!
Also, wrap the inner portion of each tab with an anchor tag (to match markup on existing projects).