### PR TITLE
Hide error

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -765,7 +765,7 @@ function EmailInput ({
 
 ## LabeledField
 
-A fieldset wrapper for redux-form controlled inputs. This wrapper adds an [InputLabel](#inputlabel) 
+A fieldset wrapper for redux-form controlled inputs. This wrapper adds an [InputLabel](#inputlabel)
 above the wrapped component and an [InputError](#inputerror) below. Additionally, it adds the class `"error"`
 to the fieldset if the input is touched and invalid.
 
@@ -773,13 +773,17 @@ In order to populate the `InputLabel` and `InputError` correctly, you should pas
 to this component. To prevent label-specific props from being passed to the input itself,
 use the [omitLabelProps](#omitlabelprops) helper.
 
+**Parameters**
+
+-   `hideErrorLabel` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** A boolean determining whether the error label should appear on input error (optional, default `false`)
+
 **Examples**
 
 ```javascript
 // A custom input to use with redux-forms
 
 function LabeledPhoneInput (props) {
-  const {  
+  const {
      input: { name, value, onBlur, onChange },
      ...rest,
   } = omitLabelProps(props)
@@ -790,7 +794,7 @@ function LabeledPhoneInput (props) {
          name,
          value,
          onBlur,
-         onChange,   
+         onChange,
          ...rest,
        }}
     </LabeledField>

--- a/docs.md
+++ b/docs.md
@@ -776,7 +776,7 @@ use the [omitLabelProps](#omitlabelprops) helper.
 
 **Parameters**
 
--   `hideErrorLabel` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** A boolean determining whether the error label should appear on input error (optional, default `false`)
+-   `hideErrorLabel` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** A boolean determining whether to hide the error label on input error (optional, default `false`)
 
 **Examples**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/forms/labels/labeled-field.js
+++ b/src/forms/labels/labeled-field.js
@@ -16,7 +16,7 @@ import InputLabel from './input-label'
  *
  * @name LabeledField
  * @type Function
- * @param {Boolean} [hideErrorLabel] A boolean determining whether the error label should appear on input error (optional, default `false`)
+ * @param {Boolean} [hideErrorLabel] A boolean determining whether to hide the error label on input error (optional, default `false`)
  *
  * @example
  *

--- a/src/forms/labels/labeled-field.js
+++ b/src/forms/labels/labeled-field.js
@@ -6,23 +6,24 @@ import InputLabel from './input-label'
 
 /**
  *
- * A fieldset wrapper for redux-form controlled inputs. This wrapper adds an {@link InputLabel} 
+ * A fieldset wrapper for redux-form controlled inputs. This wrapper adds an {@link InputLabel}
  * above the wrapped component and an {@link InputError} below. Additionally, it adds the class `"error"`
  * to the fieldset if the input is touched and invalid.
- * 
+ *
  * In order to populate the `InputLabel` and `InputError` correctly, you should pass all the props of the corresponding input
  * to this component. To prevent label-specific props from being passed to the input itself,
  * use the {@link omitLabelProps} helper.
  *
  * @name LabeledField
  * @type Function
+ * @param {Boolean} [hideErrorLabel] A boolean determining whether the error label should appear on input error (optional, default `false`)
  *
  * @example
- * 
+ *
  * // A custom input to use with redux-forms
- * 
+ *
  * function LabeledPhoneInput (props) {
- *   const {  
+ *   const {
  *      input: { name, value, onBlur, onChange },
  *      ...rest,
  *   } = omitLabelProps(props)
@@ -33,7 +34,7 @@ import InputLabel from './input-label'
  *          name,
  *          value,
  *          onBlur,
- *          onChange,   
+ *          onChange,
  *          ...rest,
  *        }}
  *     </LabeledField>
@@ -45,7 +46,12 @@ import InputLabel from './input-label'
 const propTypes = {
   ...InputLabel.propTypes,
   ...InputError.propTypes,
-  children: PropTypes.node
+  children: PropTypes.node,
+  hideErrorLabel: PropTypes.bool,
+}
+
+const defaultProps = {
+  hideErrorLabel: false,
 }
 
 function LabeledField ({
@@ -55,17 +61,20 @@ function LabeledField ({
     hint,
     label,
     tooltip,
-    children
+    children,
+    hideErrorLabel,
   }) {
   return (
     <fieldset className={ classnames(className, { 'error': touched && invalid }) }>
       <InputLabel { ...{ hint, label, name, tooltip } } />
         { children }
-      <InputError { ...{ error, invalid, touched } } />
+      { !hideErrorLabel && <InputError { ...{ error, invalid, touched } } /> }
     </fieldset>
   )
 }
 
 LabeledField.propTypes = propTypes
+
+LabeledField.defaultProps = defaultProps
 
 export default LabeledField

--- a/stories/forms/labels/labeled-field.story.js
+++ b/stories/forms/labels/labeled-field.story.js
@@ -31,4 +31,19 @@ storiesOf('LabeledField', module)
       <Input />
     </LabeledField>
   ))
+  .add('hide error', () => (
+    <LabeledField {...{
+      input: {
+        name: 'input name'
+      },
+      meta: {
+        touched: true,
+        invalid: true,
+        error: 'Error message',
+      },
+      hideErrorLabel: true,
+    }}>
+      <Input />
+    </LabeledField>
+  ))
 

--- a/test/forms/labels/labeled-field.test.js
+++ b/test/forms/labels/labeled-field.test.js
@@ -26,3 +26,11 @@ test('adds InputLabel and InputError', () => {
   // InputError
   expect(wrapper.find('.error-message').exists()).toEqual(true)
 })
+
+test('hides error label with hideErrorLabel option', () => {
+  const Wrapped = () => <input name="test"/>
+  const props = { input: { name: 'foo' }, meta: { touched: true, invalid: true }, hideErrorLabel: true }
+  const wrapper = mount(<LabeledField { ...props } ><Wrapped /></LabeledField>)
+  // InputError
+  expect(wrapper.find('.error-message').exists()).toEqual(false)
+})


### PR DESCRIPTION
Resolves #140 

- Added 'hideErrorLabel' prop to 'LabeledFields' component
  - defaults to `false`
  - `true` does not render the `InputError` component
  - Update src, story, test, and docs