### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 # lp-components
 Reusable UI components for React apps.
 
-## Documentation 
+## Documentation
 Documentation and usage info can be found in [docs.md](docs.md).
+
+## Migration Guides
+- [v2.0.0](migration-guides/v2.0.0.md)
 
 ## Contribution
 This package follows the Opex [NPM package guidelines](https://github.com/LaunchPadLab/opex/blob/master/gists/npm-package-guidelines.md). Please refer to the linked document for information on contributing, testing and versioning.
@@ -12,7 +15,7 @@ This package follows the Opex [NPM package guidelines](https://github.com/Launch
 ## Additional info
 
 #### React Storybook
-This library uses [React Storybook](https://getstorybook.io/) to render components in a development sandbox. In order to view the storybook, run `yarn run storybook` and navigate to the localhost port indicated. 
+This library uses [React Storybook](https://getstorybook.io/) to render components in a development sandbox. In order to view the storybook, run `yarn run storybook` and navigate to the localhost port indicated.
 
 *Every new component added to this library should be accompanied by a new story in the storybook.*
 
@@ -24,7 +27,7 @@ The `DateInput` component requires special styles in order to render correctly. 
 
 #### `webpack.config.js`:
 
-Add a line near the top of the file specifying the path to the `react-datepicker` styles: 
+Add a line near the top of the file specifying the path to the `react-datepicker` styles:
 
 `const datePickerPath = path.resolve(__dirname, '../node_modules/react-datepicker/src/stylesheets')`
 
@@ -35,7 +38,7 @@ Then, add this path to the `includePaths` array of the sass loader:
     loader: "sass",
     query: { includePaths: [ ... , datePickerPath ] }
 }
-``` 
+```
 
 #### `application.scss`:
 

--- a/docs.md
+++ b/docs.md
@@ -34,7 +34,7 @@
 -   [SortableTable](#sortabletable)
 -   [TableColumn](#tablecolumn)
 -   [compareAtPath](#compareatpath)
--   [objectify](#objectify)
+-   [serializeOptions](#serializeoptions)
 -   [stripNamespace](#stripnamespace)
 
 ## Paginator
@@ -268,11 +268,11 @@ export default CoolPersonForm
 
 ## CheckboxGroup
 
-A group of checkboxes that can be used in a `redux-forms`-controlled form. 
+A group of checkboxes that can be used in a `redux-forms`-controlled form.
 
 The value of each checkbox is specified via the `options` prop. This prop can either be:
 
--   An array of strings 
+-   An array of strings
 -   An array of key-value pairs: `{ key, value }`
 
 The value of the entire `CheckboxGroup` component is an **array** containing the values of the selected checkboxes.
@@ -290,7 +290,7 @@ Clicking an unselected checkbox adds its value to this array, and clicking a sel
 function TodoForm ({ handleSubmit, pristine, invalid, submitting }) {
   return (
     <form onSubmit={ handleSubmit }>
-      <Field 
+      <Field
          name="completedTodos"
          component={ CheckboxGroup }
          options={[
@@ -510,11 +510,11 @@ function StudentForm ({ handleSubmit, pristine, invalid, submitting }) {
 
 ## RadioGroup
 
-A group of radio buttons that can be used in a `redux-forms`-controlled form. 
+A group of radio buttons that can be used in a `redux-forms`-controlled form.
 
 The value of each button is specified via the `options` prop. This prop can either be:
 
--   An array of strings 
+-   An array of strings
 -   An array of key-value pairs: `{ key, value }`
 
 The value of the entire `RadioGroup` component is the value of the currently selected button.
@@ -531,7 +531,7 @@ The value of the entire `RadioGroup` component is the value of the currently sel
 function FavoriteFoodForm ({ handleSubmit, pristine, invalid, submitting }) {
   return (
     <form onSubmit={ handleSubmit }>
-      <Field 
+      <Field
          name="favoriteFood"
          component={ RadioGroup }
          options={[
@@ -552,11 +552,11 @@ export default FavoriteFoodForm
 
 ## Select
 
-A select input that can be used in a `redux-forms`-controlled form. 
+A select input that can be used in a `redux-forms`-controlled form.
 
 The value of each option is specified via the `options` prop. This prop can either be:
 
--   An array of strings 
+-   An array of strings
 -   An array of key-value pairs: `{ key, value }`
 
 The value of the `Select` component will be the same as the value of the selected option.
@@ -577,7 +577,7 @@ The value of the `Select` component will be the same as the value of the selecte
 function PaintColorForm ({ handleSubmit, pristine, invalid, submitting }) {
   return (
     <form onSubmit={ handleSubmit }>
-      <Field 
+      <Field
          name="paintColor"
          component={ Select }
          options={[
@@ -598,7 +598,7 @@ function PaintColorForm ({ handleSubmit, pristine, invalid, submitting }) {
 function EmployeeForm ({ handleSubmit, pristine, invalid, submitting }) {
   return (
     <form onSubmit={ handleSubmit }>
-      <Field 
+      <Field
          name="employeeId"
          component={ Select }
          options={[
@@ -1035,7 +1035,7 @@ people.sort(ageComparator)
 
 Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** Comparison function
 
-## objectify
+## serializeOptions
 
 Function that transforms string options into object options with keys of
 `key` and `value`
@@ -1049,7 +1049,7 @@ Function that transforms string options into object options with keys of
 ```javascript
 const options = ['apple', 'banana']
 
-objectify(options)
+serializeOptions(options)
 
 // [{ key: 'apple', value: 'apple' }, { key: 'banana', value: 'banana' }]
 ```

--- a/docs.md
+++ b/docs.md
@@ -653,8 +653,8 @@ A textarea input that can be used in a `redux-forms`-controlled form. Optionally
 
 -   `input` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** A `redux-forms` [input](http://redux-form.com/6.5.0/docs/api/Field.md/#input-props) object
 -   `meta` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
--   `maxLength` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** The maximum allowed length of the input. Accepts `false` for the option to not set a max length. (optional, default `500`)
--   `showCharacterCount` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Whether or not to display a character count (optional, default `true`)
+-   `maxLength` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** The maximum allowed length of the input
+-   `hideCharacterCount` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Whether to hide the character count if given a maxLength (optional, default `false`)
 
 **Examples**
 
@@ -666,7 +666,6 @@ function BiographyForm ({ handleSubmit, pristine, invalid, submitting }) {
          name="biography"
          component={ Textarea }
          maxLength={ 1000 }
-         showCharacterCount={ false }
       />
       <SubmitButton {...{ pristine, invalid, submitting }}>
         Submit

--- a/migration-guides/v2.0.0.md
+++ b/migration-guides/v2.0.0.md
@@ -1,0 +1,11 @@
+# v2.0.0 Migration Guide
+
+There are three breaking changes in this version:
+
+1. `objectify()` has been renamed to `serializeOptions()`
+2. The deprecated `submit` component has been removed
+3. Props for the `Textarea` input component have changed:
+    - `maxLength` now defaults to `false`. Provide a number to implement a maximum number of characters.
+    - `showCharacterCount` has been renamed to `hideCharacterCount`
+    - `hideCharacterCount` defaults to `false` (to match the default absence of `maxLength`).
+  Pass down `true` to hide the character count if you've provided a `maxLength` but do not want it shown.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "1.31.0",
+  "version": "2.0.0",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/controls/tab-bar.js
+++ b/src/controls/tab-bar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { fieldOptionsType } from '../forms/helpers/field-prop-types'
-import { objectify, noop } from '../utils'
+import { serializeOptions, noop } from '../utils'
 
 /**
  *
@@ -48,7 +48,7 @@ const defaultProps = {
 }
 
 function TabBar ({ vertical, options, value, onChange, className, activeClassName }) {
-  const optionObjects = objectify(options)
+  const optionObjects = serializeOptions(options)
   const alignment = vertical ? 'vertical' : 'horizontal'
   return (
     <ul className={ classnames('tabs', `${alignment}-tabs`, className) }>

--- a/src/forms/buttons/index.js
+++ b/src/forms/buttons/index.js
@@ -1,4 +1,3 @@
 export Button from './button'
 export ButtonArea from './button-area'
-export Submit from './submit'
 export SubmitButton from './submit-button'

--- a/src/forms/buttons/submit.js
+++ b/src/forms/buttons/submit.js
@@ -1,9 +1,0 @@
-import { default as SubmitButton } from './submit-button'
-import { deprecate } from '../../utils'
-
-const warning = 
-`Submit is deprecated and will be removed 
-in the next major version of lp-components. 
-Use SubmitButton instead.`
-
-export default deprecate(warning)(SubmitButton)

--- a/src/forms/inputs/checkbox-group.js
+++ b/src/forms/inputs/checkbox-group.js
@@ -1,37 +1,37 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Checkbox from './checkbox'
-import { 
+import {
   fieldPropTypesWithValue,
   fieldOptionsType,
   omitLabelProps,
   replaceEmptyStringValue,
 } from '../helpers'
 import { LabeledField } from '../labels'
-import { addToArray, removeFromArray, objectify, compose } from '../../utils'
+import { addToArray, removeFromArray, serializeOptions, compose } from '../../utils'
 
 /**
  *
- * A group of checkboxes that can be used in a `redux-forms`-controlled form. 
- * 
+ * A group of checkboxes that can be used in a `redux-forms`-controlled form.
+ *
  * The value of each checkbox is specified via the `options` prop. This prop can either be:
- * - An array of strings 
+ * - An array of strings
  * - An array of key-value pairs: `{ key, value }`
- * 
+ *
  * The value of the entire `CheckboxGroup` component is an **array** containing the values of the selected checkboxes.
  * Clicking an unselected checkbox adds its value to this array, and clicking a selected checkbox removes its value from this array.
- * 
+ *
  * @name CheckboxGroup
  * @type Function
  * @param {Object} input - A `redux-forms` [input](http://redux-form.com/6.5.0/docs/api/Field.md/#input-props) object
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
  * @param {Array} options - An array of checkbox values (strings or key-value pairs)
  * @example
- * 
+ *
  * function TodoForm ({ handleSubmit, pristine, invalid, submitting }) {
  *   return (
  *     <form onSubmit={ handleSubmit }>
- *       <Field 
+ *       <Field
  *          name="completedTodos"
  *          component={ CheckboxGroup }
  *          options={[
@@ -73,7 +73,7 @@ function CheckboxGroup (props) {
     options,
     ...rest
   } = omitLabelProps(props)
-  const optionObjects = objectify(options)
+  const optionObjects = serializeOptions(options)
   // Build change handler
   const handleChange = function (option) {
     return function (checked) {

--- a/src/forms/inputs/radio-group.js
+++ b/src/forms/inputs/radio-group.js
@@ -1,35 +1,35 @@
 import React from 'react'
 // import PropTypes from 'prop-types'
 import Input from './input'
-import { 
+import {
   fieldPropTypes,
   fieldOptionsType,
   omitLabelProps,
 } from '../helpers'
 import { LabeledField } from '../labels'
-import { objectify } from '../../utils'
+import { serializeOptions } from '../../utils'
 
 /**
  *
- * A group of radio buttons that can be used in a `redux-forms`-controlled form. 
- * 
+ * A group of radio buttons that can be used in a `redux-forms`-controlled form.
+ *
  * The value of each button is specified via the `options` prop. This prop can either be:
- * - An array of strings 
+ * - An array of strings
  * - An array of key-value pairs: `{ key, value }`
- * 
+ *
  * The value of the entire `RadioGroup` component is the value of the currently selected button.
- * 
+ *
  * @name RadioGroup
  * @type Function
  * @param {Object} input - A `redux-forms` [input](http://redux-form.com/6.5.0/docs/api/Field.md/#input-props) object
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
  * @param {Array} options - An array of button values (strings or key-value pairs)
  * @example
- * 
+ *
  * function FavoriteFoodForm ({ handleSubmit, pristine, invalid, submitting }) {
  *   return (
  *     <form onSubmit={ handleSubmit }>
- *       <Field 
+ *       <Field
  *          name="favoriteFood"
  *          component={ RadioGroup }
  *          options={[
@@ -64,7 +64,7 @@ function RadioGroup (props) {
     options,
     ...rest
   } = omitLabelProps(props)
-  const optionObjects = objectify(options)
+  const optionObjects = serializeOptions(options)
   return (
     <LabeledField className="RadioGroup" { ...props }>
       {

--- a/src/forms/inputs/select.js
+++ b/src/forms/inputs/select.js
@@ -3,18 +3,18 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { blurDirty, fieldPropTypes, fieldOptionsType, omitLabelProps } from '../helpers'
 import { LabeledField } from '../labels'
-import { compose, objectify } from '../../utils'
+import { compose, serializeOptions } from '../../utils'
 
 /**
  *
- * A select input that can be used in a `redux-forms`-controlled form. 
- * 
+ * A select input that can be used in a `redux-forms`-controlled form.
+ *
  * The value of each option is specified via the `options` prop. This prop can either be:
- * - An array of strings 
+ * - An array of strings
  * - An array of key-value pairs: `{ key, value }`
- * 
+ *
  * The value of the `Select` component will be the same as the value of the selected option.
- * 
+ *
  * @name Select
  * @type Function
  * @param {Object} input - A `redux-forms` [input](http://redux-form.com/6.5.0/docs/api/Field.md/#input-props) object
@@ -25,11 +25,11 @@ import { compose, objectify } from '../../utils'
  * @example
  *
  * // With string options
- * 
+ *
  * function PaintColorForm ({ handleSubmit, pristine, invalid, submitting }) {
  *   return (
  *     <form onSubmit={ handleSubmit }>
- *       <Field 
+ *       <Field
  *          name="paintColor"
  *          component={ Select }
  *          options={[
@@ -50,7 +50,7 @@ import { compose, objectify } from '../../utils'
  * function EmployeeForm ({ handleSubmit, pristine, invalid, submitting }) {
  *   return (
  *     <form onSubmit={ handleSubmit }>
- *       <Field 
+ *       <Field
  *          name="employeeId"
  *          component={ Select }
  *          options={[
@@ -88,10 +88,10 @@ function Select (props) {
     placeholder,
     ...rest
   } = omitLabelProps(props)
-  const optionObjects = objectify(options)
+  const optionObjects = serializeOptions(options)
   return (
     <LabeledField { ...props }>
-      <select 
+      <select
         {...{
           id: name,
           className: classnames({ 'unselected': value === '' }),
@@ -99,16 +99,16 @@ function Select (props) {
           value,
           onBlur,
           onChange,
-          ...rest 
+          ...rest
         }}
       >
-        { 
+        {
           placeholder &&
           <option value='' disabled={ !enablePlaceholderOption }>
             { placeholder }
           </option>
         }
-        { 
+        {
           optionObjects.map(({ key, value }) =>
             <option key={ key } value={ value }>
               { key }

--- a/src/forms/inputs/textarea.js
+++ b/src/forms/inputs/textarea.js
@@ -13,8 +13,8 @@ import { compose } from '../../utils'
  * @type Function
  * @param {Object} input - A `redux-forms` [input](http://redux-form.com/6.5.0/docs/api/Field.md/#input-props) object
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
- * @param {Number} [maxLength=500] - The maximum allowed length of the input. Accepts `false` for the option to not set a max length.
- * @param {Boolean} [showCharacterCount=true] - Whether or not to display a character count
+ * @param {Number} [maxLength] - The maximum allowed length of the input
+ * @param {Boolean} [hideCharacterCount=false] - Whether to hide the character count if given a maxLength
  * @example
  *
  * function BiographyForm ({ handleSubmit, pristine, invalid, submitting }) {
@@ -24,7 +24,6 @@ import { compose } from '../../utils'
  *          name="biography"
  *          component={ Textarea }
  *          maxLength={ 1000 }
- *          showCharacterCount={ false }
  *       />
  *       <SubmitButton {...{ pristine, invalid, submitting }}>
  *         Submit
@@ -36,31 +35,31 @@ import { compose } from '../../utils'
 
 const propTypes = {
   ...fieldPropTypes,
-  showCharacterCount: PropTypes.bool,
+  hideCharacterCount: PropTypes.bool,
   maxLength: PropTypes.oneOfType([PropTypes.number, PropTypes.bool])
 }
 
 const defaultProps = {
-  maxLength: 500,
-  showCharacterCount: true,
+  maxLength: false,
+  hideCharacterCount: false,
 }
 
 function Textarea (props) {
   const {
     input: { name, value, onBlur, onChange },
     meta, // eslint-disable-line no-unused-vars
-    showCharacterCount,
+    hideCharacterCount,
     className,
     maxLength,
     ...rest
   } = omitLabelProps(props)
   return (
     <LabeledField
-      className={ classnames(className, { 'with-character-count': showCharacterCount }) }
+      className={ classnames(className, { 'with-character-count': !hideCharacterCount }) }
       { ...props }
     >
       {
-        !!maxLength && showCharacterCount &&
+        maxLength !== false && !hideCharacterCount &&
         <span className="character-count">
           { `${ value.length }/${ maxLength } characters` }
         </span>

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ export * from './forms'
 export * from './tables'
 export {
   compareAtPath,
-  objectify,
+  serializeOptions,
   stripNamespace,
 } from './utils'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -16,15 +16,15 @@ export {
 export wrapDisplayName from 'recompose/wrapDisplayName'
 
 // LP Utils
-export { 
+export {
   deprecate,
   sortable,
   sortablePropTypes,
   toggle,
-  togglePropTypes, 
+  togglePropTypes,
 } from '@launchpadlab/lp-hoc'
 
 // Local
 export compareAtPath from './compare-at-path'
-export objectify from './objectify'
+export serializeOptions from './serialize-options'
 export stripNamespace from './strip-namespace'

--- a/src/utils/serialize-options.js
+++ b/src/utils/serialize-options.js
@@ -3,22 +3,22 @@
  * Function that transforms string options into object options with keys of
  * `key` and `value`
  *
- * @name objectify
+ * @name serializeOptions
  * @type Function
  * @param {Array} optionArray - Array of option values
  * @returns {Array} Array of object options
  *
  * @example
- * 
+ *
  * const options = ['apple', 'banana']
- * 
- * objectify(options)
+ *
+ * serializeOptions(options)
  *
  * // [{ key: 'apple', value: 'apple' }, { key: 'banana', value: 'banana' }]
  *
 **/
 
-export default function objectify (optionArray) {
+export default function serializeOptions (optionArray) {
   return optionArray.map((option) => {
     return (typeof option === 'string') ? { key: option, value: option } : option
   })

--- a/stories/forms/inputs/textarea-story.js
+++ b/stories/forms/inputs/textarea-story.js
@@ -31,13 +31,7 @@ storiesOf('Textarea', module)
     <Textarea
       input={inputProps}
       meta={{}}
-      showCharacterCount={false}
-    />
-  ))
-  .add('with no maxLength', () => (
-    <Textarea
-      input={inputProps}
-      meta={{}}
-      maxLength={0}
+      maxLength={50}
+      hideCharacterCount={true}
     />
   ))

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -2,7 +2,20 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { Textarea } from '../../../src/'
 
-test('Textarea passes down max length correctly', () => {
+test('Textarea passes down defaults and does not show character count', () => {
+  const props = {
+    input: {
+      name: 'test',
+      value: '',
+    },
+    meta: {},
+  }
+  const wrapper = shallow(<Textarea { ...props }/>)
+  expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(false)
+  expect(wrapper.dive().find('.character-count').exists()).toEqual(false)
+})
+
+test('Textarea passes down max length and shows character count correctly', () => {
   const props = {
     input: {
       name: 'test',
@@ -13,6 +26,7 @@ test('Textarea passes down max length correctly', () => {
   }
   const wrapper = shallow(<Textarea { ...props }/>)
   expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(5)
+  expect(wrapper.dive().find('.character-count').exists()).toEqual(true)
 })
 
 test('Textarea hides character count correctly', () => {
@@ -22,23 +36,12 @@ test('Textarea hides character count correctly', () => {
       value: '',
     },
     meta: {},
-    showCharacterCount: false,
+    maxLength: 5,
+    hideCharacterCount: true,
   }
   const wrapper = shallow(<Textarea { ...props }/>)
+  expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(5)
   expect(wrapper.dive().find('.character-count').exists()).toEqual(false)
 })
 
-test('Textarea passes down max length and hides character count correctly', () => {
-  const props = {
-    input: {
-      name: 'test',
-      value: '',
-    },
-    meta: {},
-    maxLength: false,
-  }
-  const wrapper = shallow(<Textarea { ...props }/>)
-  expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(false)
-  expect(wrapper.dive().find('.character-count').exists()).toEqual(false)
-})
 

--- a/test/utils/serialize-options.test.js
+++ b/test/utils/serialize-options.test.js
@@ -1,22 +1,22 @@
-import { objectify } from '../../src/'
+import { serializeOptions } from '../../src'
 
 test('when the argument is not an array - throws an error', () => {
   const optionArray = ''
-  expect(() => objectify(optionArray)).toThrow(TypeError)
+  expect(() => serializeOptions(optionArray)).toThrow(TypeError)
 })
 
 test('when the argument is an empty array - returns the argument', () => {
   const optionArray = []
-  expect(objectify(optionArray)).toEqual([])
+  expect(serializeOptions(optionArray)).toEqual([])
 })
 
 test('when the argument is an array of objects - returns the argument', () => {
   const optionArray = [{ foo: 'bar' }]
-  expect(objectify(optionArray)).toEqual([{ foo: 'bar' }])
+  expect(serializeOptions(optionArray)).toEqual([{ foo: 'bar' }])
 })
 
 test('when the argument is an array of strings - returns the strings as array of objects', () => {
   const optionArray = ['foo', 'bar']
-  expect(objectify(optionArray)).toEqual([{ key: 'foo', value: 'foo' }, { key: 'bar', value: 'bar' }])
+  expect(serializeOptions(optionArray)).toEqual([{ key: 'foo', value: 'foo' }, { key: 'bar', value: 'bar' }])
 })
 


### PR DESCRIPTION
1. `objectify()` has been renamed to `serializeOptions()`
2. The deprecated `submit` component has been removed
3. Props for the `Textarea` input component have changed:
    - `maxLength` now defaults to `false`. Provide a number to implement a maximum number of characters.
    - `showCharacterCount` has been renamed to `hideCharacterCount`
    - `hideCharacterCount` defaults to `false` (to match the default absence of `maxLength`).
  Pass down `true` to hide the character count if you've provided a `maxLength` but do not want it shown.