### PR TITLE
Wrap file input in a `div` instead of `Button`

### DIFF
--- a/.storybook/styles/components/_forms.scss
+++ b/.storybook/styles/components/_forms.scss
@@ -254,17 +254,50 @@ Input Tooltip
 Uploader
 -----------------------*/
 .fileupload{
+
+  .thumbnail{
+    display: inline-block;
+    @include rem(margin-right, 15px);
+    width: 70px;
+    vertical-align: middle;
+
+    img{
+      border-radius: 50%;
+      height: 70px;
+    }
+  }
+
   .button-secondary-light{
     overflow: hidden;
     position: relative;
     vertical-align: middle;
-    //background-color: $white-med;
+    background-color: $grey-base;
     box-shadow: none;
     border: none;
     cursor: pointer;
+    color: $white-base;
+    text-align: center;
 
     &:hover{
-      //background-color: $grey-base;
+      background-color: darken($grey-base, 8%);
+    }
+
+    .fileupload-exists{
+      color: $white-base;
+    }
+  }
+
+  &.fileupload-exists{
+    div{
+      padding: 0px !important;
+
+      span{
+        //border: 1px solid $grey-base;
+        display: inline-block;
+        //@include rem(padding, 15px);
+        @include rem(margin, 20px 0px);
+        color: $black-base;
+      }
     }
   }
 
@@ -293,7 +326,7 @@ Uploader
 .close{
   text-decoration: none;
   vertical-align: text-bottom;
-  border: none;
+  // border: none;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/forms/buttons/button.js
+++ b/src/forms/buttons/button.js
@@ -53,7 +53,7 @@ function Button ({ children, type, style, pristine, invalid, submitting, ...rest
   return (
     <button
       type={ type }
-      className={ buttonClasses(style, pristine, invalid, submitting) }
+      className={ buttonClasses({ style, pristine, invalid, submitting }) }
       disabled={ pristine || invalid }
       { ...rest }
     >

--- a/src/forms/buttons/button.js
+++ b/src/forms/buttons/button.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import { buttonClasses } from '../helpers'
 
 /**
  *
@@ -53,22 +53,12 @@ function Button ({ children, type, style, pristine, invalid, submitting, ...rest
   return (
     <button
       type={ type }
-      className={ classes(style, pristine, invalid, submitting) }
+      className={ buttonClasses(style, pristine, invalid, submitting) }
       disabled={ pristine || invalid }
       { ...rest }
     >
       { children }
     </button>
-  )
-}
-
-function classes (style, pristine, invalid, submitting) {
-  return classnames(
-    `button-${style}`,
-    {
-      'is-disabled': pristine || invalid,
-      'in-progress': submitting,
-    }
   )
 }
 

--- a/src/forms/helpers/button-classes.js
+++ b/src/forms/helpers/button-classes.js
@@ -1,0 +1,11 @@
+import classnames from 'classnames'
+
+export default function buttonClasses (style, pristine, invalid, submitting) {
+  return classnames(
+    `button-${style}`,
+    {
+      'is-disabled': pristine || invalid,
+      'in-progress': submitting,
+    }
+  )
+}

--- a/src/forms/helpers/button-classes.js
+++ b/src/forms/helpers/button-classes.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 
-export default function buttonClasses (style, pristine, invalid, submitting) {
+export default function buttonClasses ({ style, pristine, invalid, submitting }) {
   return classnames(
     `button-${style}`,
     {

--- a/src/forms/helpers/index.js
+++ b/src/forms/helpers/index.js
@@ -1,4 +1,5 @@
 export blurDirty from './blur-dirty'
+export buttonClasses from './button-classes'
 export convertNameToLabel from './convert-name-to-label'
 export * from './field-prop-types'
 export omitLabelProps from './omit-label-props'

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button } from '../../buttons'
-import { fieldPropTypes, omitLabelProps } from '../../helpers'
+import { buttonClasses, fieldPropTypes, omitLabelProps } from '../../helpers'
 import { LabeledField } from '../../labels'
 import ImagePreview from './image-preview'
 import { noop } from '../../../utils'
@@ -91,18 +90,21 @@ class FileInput extends React.Component {
       meta,   // eslint-disable-line no-unused-vars
       onLoad, // eslint-disable-line no-unused-vars
       className, // eslint-disable-line no-unused-vars
+      invalid,
+      pristine,
       submitting,
       accept,
       ...rest
     } = omitLabelProps(this.props)
     const { file } = this.state
+    const wrapperClass = buttonClasses('secondary-light', pristine, invalid, submitting)
     return (
       <LabeledField { ...this.props }>
         <div className="fileupload fileupload-exists">
           { 
             renderPreview({ file, value, ...rest })
           }
-          <Button style="secondary-light" submitting={ submitting }>
+          <div className={ wrapperClass }>
             <span className="fileupload-exists"> Select File </span>
               <input 
                 {...{
@@ -113,7 +115,7 @@ class FileInput extends React.Component {
                   accept,
                 }}
               />
-          </Button>
+          </div>
         </div>
       </LabeledField>
     )

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -97,7 +97,7 @@ class FileInput extends React.Component {
       ...rest
     } = omitLabelProps(this.props)
     const { file } = this.state
-    const wrapperClass = buttonClasses('secondary-light', pristine, invalid, submitting)
+    const wrapperClass = buttonClasses({ style: 'secondary-light', pristine, invalid, submitting })
     return (
       <LabeledField { ...this.props }>
         <div className="fileupload fileupload-exists">

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -90,14 +90,12 @@ class FileInput extends React.Component {
       meta,   // eslint-disable-line no-unused-vars
       onLoad, // eslint-disable-line no-unused-vars
       className, // eslint-disable-line no-unused-vars
-      invalid,
-      pristine,
       submitting,
       accept,
       ...rest
     } = omitLabelProps(this.props)
     const { file } = this.state
-    const wrapperClass = buttonClasses({ style: 'secondary-light', pristine, invalid, submitting })
+    const wrapperClass = buttonClasses({ style: 'secondary-light', submitting })
     return (
       <LabeledField { ...this.props }>
         <div className="fileupload fileupload-exists">

--- a/test/forms/helpers/button-classes.test.js
+++ b/test/forms/helpers/button-classes.test.js
@@ -1,0 +1,18 @@
+import { buttonClasses } from '../../../src/'
+
+test('returns style with `button-` prepended', () => {
+  expect(buttonClasses({ style: 'primary' })).toEqual('button-primary')
+})
+
+test('returns correct classes when submitting', () => {
+  expect(buttonClasses({ style: 'primary', submitting: true })).toEqual('button-primary in-progress')
+})
+
+test('returns correct classes when invalid', () => {
+  expect(buttonClasses({ style: 'primary', invalid: true })).toEqual('button-primary is-disabled')
+})
+
+test('returns correct classes when pristine', () => {
+  expect(buttonClasses({ style: 'primary', pristine: true })).toEqual('button-primary is-disabled')
+})
+


### PR DESCRIPTION
Resolves #199 

Also moves `classes` function to a helper.

This will break some styles on the apps currently using `FileInput`, so I'm thinking this should be a major change.