### PR TITLE
Fix SortableTable reset bug

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -979,6 +979,7 @@ This component's behavior is largely determined by the [TableColumn](#tablecolum
 
 -   `data` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** An array of objects to display in the table- one object per row (optional, default `[]`)
 -   `initialColumn` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The name of the column that's initially selected (optional, default `''`)
+-   `disableReverse` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Disables automatic reversing of descending sorts (optional, default `false`)
 -   `disableSort` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** A flag to disable sorting on all columns (optional, default `false`)
 -   `onChange` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** A callback that will be fired when the sorting state changes
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lib/"
   ],
   "dependencies": {
-    "@launchpadlab/lp-hoc": "^1.2.0",
+    "@launchpadlab/lp-hoc": "^2.0.0",
     "classnames": "^2.2.5",
     "codeclimate-test-reporter": "^0.5.0",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/tables/sortable-table.js
+++ b/src/tables/sortable-table.js
@@ -13,6 +13,7 @@ import classnames from 'classnames'
  * @type Function
  * @param {Array} [data=[]] - An array of objects to display in the table- one object per row
  * @param {Number} [initialColumn=''] - The name of the column that's initially selected
+ * @param {Boolean} [disableReverse=false] - Disables automatic reversing of descending sorts
  * @param {Boolean} [disableSort=false] - A flag to disable sorting on all columns
  * @param {Function} [onChange] - A callback that will be fired when the sorting state changes
  * @example
@@ -89,16 +90,23 @@ function SortableTable ({
 SortableTable.propTypes = propTypes
 SortableTable.defaultProps = defaultProps
 
-// Wraps SortableTable in sortable HOC
-function SortableTableWrapper ({ initialColumn, children, disableSort, data, onChange }) {
+const WrappedTable = sortable()(SortableTable)
+
+// Passes relevant sortable props
+function SortableTableWrapper ({ initialColumn, children, disableSort, disableReverse, data, onChange }) {
   const columns = getColumnData(children, disableSort)
   const initialProps = columns.filter(col => col.name === initialColumn).pop()
-  const WrappedTable = sortable({ 
-    sortPath: initialProps ? initialProps.name : '',
-    sortFunc: initialProps ? initialProps.sortFunc : null,
+  return <WrappedTable {...{
+    // Sortable props
+    initialSortPath: initialProps ? initialProps.name : '',
+    initialSortFunc: initialProps ? initialProps.sortFunc : null,
     onChange,
-  })(SortableTable)
-  return <WrappedTable {...{ columns, data, disableSort }} />
+    disableReverse,
+    // Local props
+    columns, 
+    data,
+    disableSort,
+  }} />
 }
 
 SortableTableWrapper.propTypes = {
@@ -106,12 +114,14 @@ SortableTableWrapper.propTypes = {
   children: PropTypes.node.isRequired,
   data: PropTypes.arrayOf(PropTypes.object),
   disableSort: PropTypes.bool,
+  disableReverse: PropTypes.bool,
   onChange: PropTypes.func,
 }
 
 SortableTableWrapper.defaultProps = {
   initialColumn: '',
   disableSort: false,
+  disableReverse: false,
   data: [],
   onChange: noop,
 }


### PR DESCRIPTION
Fixes a bug where the sort state was being reset when the props changed.
This was happening because `sortable()` was being reinitialized on every rerender.
Now, the `sortable()` initialization/wrapping happens just once, and options are passed via props.

Also adds `disableReverse` prop.

Relies on https://github.com/LaunchPadLab/lp-hoc/pull/15/