### PR TITLE
Remove `props` from Spinner component

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1032,12 +1032,12 @@ A UI component that displays a 'spinner'.
 ```javascript
 function Image ({ imgUrl }) {
   return (
-   <div>
-    { imgUrl
-      ? <img src={ imgUrl } alt=""/>
-      : <Spinner/>
-    }
-   </div>
+     <div>
+      { imgUrl
+        ? <img src={ imgUrl } alt=""/>
+        : <Spinner/>
+      }
+     </div>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@launchpadlab/lp-hoc": "^2.0.0",
     "classnames": "^2.2.5",
     "codeclimate-test-reporter": "^0.5.0",
+    "filter-invalid-dom-props": "^2.0.0",
     "lodash": "^4.17.4",
     "moment": "^2.19.3",
     "prop-types": "^15.5.8",

--- a/src/indicators/spinner.js
+++ b/src/indicators/spinner.js
@@ -28,9 +28,9 @@ import React from 'react'
 const propTypes = {
 }
 
-function Spinner (props) {
+function Spinner () {
   return (
-    <div id="spinner" {...props}/>
+    <div id="spinner" />
   )
 }
 

--- a/src/indicators/spinner.js
+++ b/src/indicators/spinner.js
@@ -1,5 +1,6 @@
 import React from 'react'
 // import PropTypes from 'prop-types'
+import filterInvalidProps from 'filter-invalid-dom-props'
 
 /**
  *
@@ -27,8 +28,8 @@ import React from 'react'
 
 const propTypes = {}
 
-function Spinner () {
-  return <div id="spinner" />
+function Spinner (props) {
+  return <div id="spinner" { ...filterInvalidProps(props) } />
 }
 
 Spinner.propTypes = propTypes

--- a/src/indicators/spinner.js
+++ b/src/indicators/spinner.js
@@ -12,12 +12,12 @@ import React from 'react'
  * 
  * function Image ({ imgUrl }) {
  *   return (
- *    <div>
- *     { imgUrl
- *       ? <img src={ imgUrl } alt=""/>
- *       : <Spinner/>
- *     }
- *    </div>
+ *      <div>
+ *       { imgUrl
+ *         ? <img src={ imgUrl } alt=""/>
+ *         : <Spinner/>
+ *       }
+ *      </div>
  *   )
  * }
  *
@@ -25,14 +25,12 @@ import React from 'react'
  *
 **/
 
-const propTypes = {
-}
+const propTypes = {}
 
 function Spinner () {
-  return (
-    <div id="spinner" />
-  )
+  return <div id="spinner" />
 }
 
 Spinner.propTypes = propTypes
+
 export default Spinner

--- a/src/indicators/spinner.js
+++ b/src/indicators/spinner.js
@@ -1,6 +1,6 @@
 import React from 'react'
 // import PropTypes from 'prop-types'
-import filterInvalidProps from 'filter-invalid-dom-props'
+import { filterInvalidProps } from '../utils'
 
 /**
  *

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,6 +13,7 @@ export {
   get,
 } from 'lodash/fp'
 
+export filterInvalidProps from 'filter-invalid-dom-props'
 export wrapDisplayName from 'recompose/wrapDisplayName'
 
 // LP Utils

--- a/test/indicators/spinner.test.js
+++ b/test/indicators/spinner.test.js
@@ -9,3 +9,17 @@ test('Spinner creates div with id "spinner"', () => {
   )
   expect(wrapper.find('div#spinner').exists()).toBe(true)
 })
+
+test('Spinner passes props', () => {
+  const wrapper = mount(
+    <Spinner name="Bob" />
+  )
+  expect(wrapper.find('div#spinner').props().name).toEqual('Bob')
+})
+
+test('Spinner filters invalid props', () => {
+  const wrapper = mount(
+    <Spinner name="Bob" someInvalidProp="I am not a valid DOM prop" />
+  )
+  expect(wrapper.find('div#spinner').props().someInvalidProp).not.toBeDefined()
+})

--- a/test/indicators/spinner.test.js
+++ b/test/indicators/spinner.test.js
@@ -9,10 +9,3 @@ test('Spinner creates div with id "spinner"', () => {
   )
   expect(wrapper.find('div#spinner').exists()).toBe(true)
 })
-
-test('Spinner passes props', () => {
-  const wrapper = mount(
-    <Spinner name="Bob" />
-  )
-  expect(wrapper.find('div#spinner').props().name).toEqual('Bob')
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,9 +86,9 @@
     eslint-plugin-jsx-a11y "^6.0.2"
     eslint-plugin-react "^7.4.0"
 
-"@launchpadlab/lp-hoc@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@launchpadlab/lp-hoc/-/lp-hoc-1.2.0.tgz#ac446a5e5f2400cc03b6f5791519523bf890bfdb"
+"@launchpadlab/lp-hoc@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@launchpadlab/lp-hoc/-/lp-hoc-2.3.0.tgz#ea634cb4ef688f37a4d685a4927ff74eab3d8e42"
   dependencies:
     "@launchpadlab/lp-redux-api" "^5.0.2"
     "@launchpadlab/lp-requests" "^3.0.0"
@@ -99,6 +99,7 @@
     react-redux "^5.0.6"
     recompose "^0.26.0"
     redux "^3.7.2"
+    redux-modal "^1.7.0"
 
 "@launchpadlab/lp-redux-api@^5.0.2":
   version "5.0.2"
@@ -7785,6 +7786,13 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-modal@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redux-modal/-/redux-modal-1.7.0.tgz#423551dcf2eafae5e739952211be490647df3e92"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    prop-types "^15.5.10"
 
 redux@^3.7.2:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,6 +4032,12 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+filter-invalid-dom-props@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filter-invalid-dom-props/-/filter-invalid-dom-props-2.0.0.tgz#527f1494cb3c4f282a73c43804153eb80c42dc2c"
+  dependencies:
+    html-attributes "1.1.0"
+
 finalhandler@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
@@ -4663,6 +4669,10 @@ home-or-tmp@^2.0.0:
 hosted-git-info@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.2.0.tgz#7a0d097863d886c0fabbdcd37bf1758d8becf8a5"
+
+html-attributes@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/html-attributes/-/html-attributes-1.1.0.tgz#82027a4fac7a6070ea6c18cc3886aea18d6dea09"
 
 html-comment-regex@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Resolves `Unknown Prop Warning` on `Spinner` component by not passing down `props`.