### PR TITLE
Default maxLength to null rather than false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/forms/inputs/textarea.js
+++ b/src/forms/inputs/textarea.js
@@ -40,7 +40,7 @@ const propTypes = {
 }
 
 const defaultProps = {
-  maxLength: false,
+  maxLength: null,
   hideCharacterCount: false,
 }
 
@@ -59,7 +59,7 @@ function Textarea (props) {
       { ...props }
     >
       {
-        maxLength !== false && !hideCharacterCount &&
+        maxLength !== null && !hideCharacterCount &&
         <span className="character-count">
           { `${ value.length }/${ maxLength } characters` }
         </span>

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -11,7 +11,7 @@ test('Textarea passes down defaults and does not show character count', () => {
     meta: {},
   }
   const wrapper = shallow(<Textarea { ...props }/>)
-  expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(false)
+  expect(wrapper.dive().find('textarea').prop('maxLength')).toEqual(null)
   expect(wrapper.dive().find('.character-count').exists()).toEqual(false)
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7962,9 +7962,9 @@ redux-actions@^2.0.3:
     lodash-es "^4.17.4"
     reduce-reducers "^0.1.0"
 
-redux-flash@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redux-flash/-/redux-flash-1.2.0.tgz#006097224cda48f3287c262fce4c268eaf596a60"
+redux-flash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redux-flash/-/redux-flash-2.0.0.tgz#7725a66a1e1544be1e9678a34c7c8bd2e7614a8d"
   dependencies:
     prop-types "^15.6.1"
     redux-actions "^2.0.3"


### PR DESCRIPTION
Default maxLength to `null` rather than `false` to resolve complaints in console regarding passing 'false' to the dom