### PR TITLE
Pass value to custom file preview

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -482,7 +482,11 @@ This callback will be passed the data URL of the file, as well as the `File` obj
 
 By default, this component displays a thumbnail preview of the loaded file. This preview can be customized
 by using the `thumbnail` or `hidePreview` props, as well as by passing a custom preview via `previewComponent` or `children`.
-A component passed using `previewComponent` will receive a `file` prop containing the uploaded file object or `null`.
+
+A component passed using `previewComponent` will receive the following props:
+
+-   `file`: the uploaded file object, or `null` if no file has been uploaded.
+-   `value`: the current value of the input (data URL or empty string)
 
 **Parameters**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -16,7 +16,10 @@ import { noop } from '../../../utils'
  *
  * By default, this component displays a thumbnail preview of the loaded file. This preview can be customized
  * by using the `thumbnail` or `hidePreview` props, as well as by passing a custom preview via `previewComponent` or `children`.
- * A component passed using `previewComponent` will receive a `file` prop containing the uploaded file object or `null`.
+ *
+ * A component passed using `previewComponent` will receive the following props:
+ * - `file`: the uploaded file object, or `null` if no file has been uploaded.
+ * - `value`: the current value of the input (data URL or empty string)
  * 
  * @name FileInput
  * @type Function
@@ -125,7 +128,7 @@ class FileInput extends React.Component {
 
 // eslint-disable-next-line react/prop-types
 function renderPreview ({ file, value, thumbnail, previewComponent: Component, children }) {
-  if (Component) return <Component file={ file } />
+  if (Component) return <Component file={ file } value={ value } />
   if (children) return children
   const renderImagePreview = isImageType(file) || thumbnail
   if (renderImagePreview) return <ImagePreview image={ value || thumbnail } />

--- a/test/forms/inputs/file-input.test.js
+++ b/test/forms/inputs/file-input.test.js
@@ -35,23 +35,32 @@ test('Fileinput hides preview correctly', () => {
 })
 
 test('Fileinput sets custom preview from children', () => {
-  const Preview = () => <blink> My preview </blink>
+  const Preview = () => <p> My preview </p>
   const props = { input: { name, value: '' }, meta: {} }
   const wrapper = mount(<FileInput { ...props }><Preview/></FileInput>)
-  expect(wrapper.find('blink').exists()).toEqual(true)
+  expect(wrapper.find('p').exists()).toEqual(true)
 })
 
 test('Fileinput sets custom preview from props', () => {
-  const Preview = ({ file }) => <blink>{ file && file.name }</blink> // eslint-disable-line react/prop-types
+  const Preview = ({ file }) => <p>{ file && file.name }</p> // eslint-disable-line react/prop-types
   const props = { input: { name, value: '' }, meta: {} }
   const wrapper = mount(<FileInput previewComponent={ Preview } { ...props }/>)
-  expect(wrapper.find('blink').exists()).toEqual(true)
+  expect(wrapper.find('p').exists()).toEqual(true)
   wrapper.setState({ file: { name: 'fileName', type: 'image/png' } })
-  expect(wrapper.find('blink').text()).toEqual('fileName')
+  expect(wrapper.find('p').text()).toEqual('fileName')
+})
+
+test('Fileinput passes value to custom preview', () => {
+  const Preview = ({ value }) => <p>{ value }</p> // eslint-disable-line react/prop-types
+  const value = 'foo'
+  const props = { input: { name, value }, meta: {} }
+  const wrapper = mount(<FileInput previewComponent={ Preview } { ...props }/>)
+  expect(wrapper.find('p').exists()).toEqual(true)
+  expect(wrapper.find('p').text()).toEqual(value)
 })
 
 test('FileInput reads files and calls change handlers correctly', () => {
-  const FILE = 'my file'
+  const FILE = { name: 'my file' }
   const FILEDATA = 'my file data'
   window.FileReader = createMockFileReader(FILEDATA)
   const onLoad = jest.fn()


### PR DESCRIPTION
Reason: when the file is an image I need the data URL rather than the file object in order to render it.