### PR TITLE
Allow custom classname on columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/tables/components/table-row.js
+++ b/src/tables/components/table-row.js
@@ -10,7 +10,7 @@ const propTypes = {
 }
 
 const DefaultRowComponent = ({ children }) => <tr>{ children }</tr> // eslint-disable-line
-const DefaultCellComponent = ({ value }) => <td>{ value }</td> // eslint-disable-line
+const DefaultCellComponent = ({ value, className }) => <td { ...{ className } }>{ value }</td> // eslint-disable-line
 
 function TableRow ({
   rowData,

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -113,6 +113,15 @@ test('column can have custom sort function', () => {
   expect(mySort).toHaveBeenCalled()
 })
 
+test('column can have custom className', () => {
+  const wrapper = mount(
+    <SortableTable data={ tableData }>
+      <Column name="name" className="foo"/>
+    </SortableTable>
+  )
+  expect(wrapper.find('td.foo').exists()).toEqual(true)
+})
+
 test('column can have custom cell component', () => {
   const MyCell = () => <td> Hi! </td> 
   const wrapper = mount(


### PR DESCRIPTION
Let me know if you think this is expected behavior, or should be added to the docs.