### PR TITLE
Fix key iteration warning on input components

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -847,7 +847,7 @@ export default FavoriteFoodForm
 
 A select input that can be used in a `redux-forms`-controlled form.
 
-The value of each option is specified via the `options` or the `optionGroups` prop. 
+The value of each option is specified via the `options` or the `optionGroups` prop.
 The `options` prop will be ignored if `optionGroups` is present.
 
 The `options` prop can either be:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Our Components",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-components",

--- a/src/forms/inputs/checkbox-group.js
+++ b/src/forms/inputs/checkbox-group.js
@@ -84,7 +84,7 @@ function CheckboxGroup (props) {
               {...{
                 key: i,
                 input: {
-                  name: `${ name }.${ option.key }`,
+                  name: `${ name }.${ option.value }`,
                   value: value.includes(option.value),
                   onChange: handleChange(option)
                 },

--- a/src/forms/inputs/radio-group.js
+++ b/src/forms/inputs/radio-group.js
@@ -76,7 +76,7 @@ function RadioGroup (props) {
                 key: i,
                 type: 'radio',
                 input: {
-                  name: `${ name }.${ option.key }`,
+                  name: `${ name }.${ option.value }`,
                   value: '',
                   onChange: () => onChange(option.value),
                 },

--- a/src/forms/inputs/select.js
+++ b/src/forms/inputs/select.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import { 
-  blurDirty, 
-  fieldPropTypes, 
+import {
+  blurDirty,
+  fieldPropTypes,
   fieldOptionGroupsType,
-  fieldOptionsType, 
-  omitLabelProps 
+  fieldOptionsType,
+  omitLabelProps
 } from '../helpers'
 import { LabeledField } from '../labels'
 import { compose, serializeOptions, serializeOptionGroups } from '../../utils'
@@ -15,14 +15,14 @@ import { compose, serializeOptions, serializeOptionGroups } from '../../utils'
  *
  * A select input that can be used in a `redux-forms`-controlled form.
  *
- * The value of each option is specified via the `options` or the `optionGroups` prop. 
+ * The value of each option is specified via the `options` or the `optionGroups` prop.
  * The `options` prop will be ignored if `optionGroups` is present.
- * 
+ *
  * The `options` prop can either be:
  * - An array of strings
  * - An array of numbers
  * - An array of key-value pairs: `{ key, value }`
- * 
+ *
  * The `optionGroups` props must be an array of objects with the following keys:
  * - `name`: The name of the option group
  * - `options`: As above, an array of strings or key-value pairs.
@@ -129,14 +129,14 @@ function Select (props) {
         }
         {
           optionGroupObjects.length
-          ? optionGroupObjects.map(({ name, options }, idx) => 
+          ? optionGroupObjects.map(({ name, options }, idx) =>
               <optgroup key={ idx } label={ name }>
                 {
-                  options.map(({ key, value }) => <option key={ key } value={ value }>{ key }</option>)
+                  options.map(({ key, value }) => <option key={ value } value={ value }>{ key }</option>)
                 }
               </optgroup>
             )
-          : optionObjects.map(({ key, value }) => <option key={ key } value={ value }>{ key }</option>)
+          : optionObjects.map(({ key, value }) => <option key={ value } value={ value }>{ key }</option>)
         }
       </select>
      </LabeledField>


### PR DESCRIPTION
Received a console warning when two select input items had the same display values (key). Updating the inputs with options to refer to the value when needing a unique identifier (e.g, they `key` or `name` of the input or option.