### PR TITLE
Fix radio group behavior

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1050,6 +1050,7 @@ Note: When using third party form libraries (e.g., [Redux Form][150]), it's like
 ### Parameters
 
 -   `name` **[String][131]** The name of the associated input
+-   `id` **[String][131]** The id of the associated input (defaults to name) (optional, default `name`)
 -   `hint` **[String][131]?** A usage hint for the associated input
 -   `label` **([String][131] \| [Boolean][133])?** Custom text for the label
 -   `tooltip` **[String][131]?** A message to display in a tooltip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.16.3",
+  "version": "3.17.0",
   "engines": {
     "node": "^8.0.0"
   },

--- a/src/forms/inputs/input.js
+++ b/src/forms/inputs/input.js
@@ -47,6 +47,7 @@ const defaultProps = {
 function Input (props) {
   const {
     input: { name, value, onBlur, onChange },
+    id,
     meta, // eslint-disable-line no-unused-vars
     className, // eslint-disable-line no-unused-vars
     type,
@@ -58,7 +59,7 @@ function Input (props) {
       <div className="input-wrapper">
         <input
           {...{
-            id: name,
+            id: id || name,
             name,
             type,
             value,

--- a/src/forms/inputs/radio-group.js
+++ b/src/forms/inputs/radio-group.js
@@ -76,10 +76,11 @@ function RadioGroup (props) {
                 key: i,
                 type: 'radio',
                 input: {
-                  name: `${ name }.${ option.value }`,
+                  name, // all radio inputs must share the same name
                   value: '',
                   onChange: () => onChange(option.value),
                 },
+                id: `${ name }.${ option.value }`, // override Input default behavior to assign id to input: { name }
                 meta: {},
                 checked: value === option.value,
                 label: option.key,

--- a/src/forms/labels/input-label.js
+++ b/src/forms/labels/input-label.js
@@ -24,6 +24,7 @@ import { toggle, togglePropTypes } from '../../utils'
  * @name InputLabel
  * @type Function
  * @param {String} name - The name of the associated input
+ * @param {String} [id=name] - The id of the associated input (defaults to name)
  * @param {String} [hint] - A usage hint for the associated input
  * @param {String|Boolean} [label] - Custom text for the label
  * @param {String} [tooltip] - A message to display in a tooltip
@@ -56,6 +57,7 @@ import { toggle, togglePropTypes } from '../../utils'
 
 const propTypes = {
   hint: PropTypes.string,
+  id: PropTypes.string,
   label: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
   name: PropTypes.string.isRequired,
   tooltip: PropTypes.string,
@@ -66,6 +68,7 @@ const propTypes = {
 
 const defaultProps = {
   hint: '',
+  id: '',
   label: '',
   tooltip: '',
   requiredIndicator: '',
@@ -73,6 +76,7 @@ const defaultProps = {
 
 function InputLabel ({
   hint,
+  id,
   label,
   name,
   tooltip,
@@ -86,7 +90,7 @@ function InputLabel ({
     <span>
       {
         label !== false &&
-        <label htmlFor={ name }>
+        <label htmlFor={ id || name }>
           { labelText }
           {
             required && requiredIndicator &&

--- a/src/forms/labels/labeled-field.js
+++ b/src/forms/labels/labeled-field.js
@@ -55,20 +55,21 @@ const defaultProps = {
 }
 
 function LabeledField ({
-    input: { name },
-    meta: { error, touched, invalid },
-    className,
-    hint,
-    label,
-    tooltip,
-    required,
-    requiredIndicator,
-    children,
-    hideErrorLabel,
-  }) {
+  id,
+  input: { name },
+  meta: { error, touched, invalid },
+  className,
+  hint,
+  label,
+  tooltip,
+  required,
+  requiredIndicator,
+  children,
+  hideErrorLabel,
+}) {
   return (
     <fieldset className={ classnames(className, { 'error': touched && invalid }) }>
-      <InputLabel { ...{ hint, label, name, tooltip, required, requiredIndicator } } />
+      <InputLabel { ...{ hint, label, name, id, tooltip, required, requiredIndicator } } />
         { children }
       { !hideErrorLabel && <InputError { ...{ error, invalid, touched } } /> }
     </fieldset>

--- a/test/forms/inputs/input.test.js
+++ b/test/forms/inputs/input.test.js
@@ -25,3 +25,15 @@ test('Input renders children', () => {
   const wrapper = mount(<Input { ...props }><Wrapped /></Input>)
   expect(wrapper.find(Wrapped).exists()).toEqual(true)
 })
+
+test('Input id defaults to name when no id is provided', () => {
+  const props = { input, meta: {} }
+  const wrapper = mount(<Input { ...props } />)
+  expect(wrapper.find('input').prop('id')).toBe(name)
+})
+
+test('Input id is set when id is provided', () => {
+  const props = { input, meta: {} }
+  const wrapper = mount(<Input {...props} id="testId" />)
+  expect(wrapper.find('input').prop('id')).toBe('testId')
+})

--- a/test/forms/inputs/radio-group.test.js
+++ b/test/forms/inputs/radio-group.test.js
@@ -19,3 +19,18 @@ test('RadioGroup changes value when buttons are clicked', () => {
   wrapper.find('input').last().simulate('change')
   expect(onChange).toHaveBeenCalledWith('Option 2')
 })
+
+test('A RadioGroup\'s inputs all have the same name', () => {
+  const name = "sameName"
+  const props = { 
+    input: {
+      name,
+      value: '',
+    }, 
+    meta: {},
+    options: ['Option 1', 'Option 2']
+  }
+  const wrapper = mount(<RadioGroup { ...props }/>)
+  expect(wrapper.find('input').first().prop('name')).toEqual(name)
+  expect(wrapper.find('input').last().prop('name')).toEqual(name)
+})

--- a/test/forms/labels/input-label.test.js
+++ b/test/forms/labels/input-label.test.js
@@ -48,3 +48,14 @@ test('when required true and custom requiredIndicator provided, show custom indi
   const wrapper = mount(<InputLabel name={name} required requiredIndicator={ '*' } />)
   expect(wrapper.find('label > span').text()).toEqual('*')
 })
+
+test('when id is _not_ provided - renders a label associated to the input name', () => {
+  const wrapper = mount(<InputLabel name={name} label="foo" />)
+  expect(wrapper.find('label').prop('htmlFor')).toBe(name)
+})
+
+test('when id is provided - renders a label associated to the input id', () => {
+  const id = 'testId'
+  const wrapper = mount(<InputLabel name={name} id={id} label="foo" />)
+  expect(wrapper.find('label').prop('htmlFor')).toBe(id)
+})


### PR DESCRIPTION
When using a keyboard to navigate into a radio group, tab will now default to the selected value (or first value if none are selected). Arrow keys can then be used to navigate between choices. Keyboard interaction behaves as expected as defined in the [ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton).

I put in a valiant effort to try and test the focus issue but that seems virtually impossible with enzyme. Let me know if you've had success elsewhere.

This resolves #292 