### PR TITLE
Hide input fully for screenreader and keyboard users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.16.3",
+  "version": "3.17.0",
   "engines": {
     "node": "^8.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.17.0",
+  "version": "3.16.4",
   "engines": {
     "node": "^8.0.0"
   },

--- a/src/forms/inputs/hidden-input.js
+++ b/src/forms/inputs/hidden-input.js
@@ -29,12 +29,13 @@ import Input from './input'
 const hiddenStyle = {
   position: 'absolute',
   left: -9999,
+  visibility: 'hidden', // removes from tab order AND screen reader
 }
 
 function HiddenInput (props) {
   return (
     <div style={ hiddenStyle }>
-      <Input tabIndex="-1" { ...props } />
+      <Input { ...props } />
     </div>
   )
 }

--- a/test/forms/inputs/hidden-input.test.js
+++ b/test/forms/inputs/hidden-input.test.js
@@ -16,9 +16,5 @@ test('HiddenInput renders a div the correct styles', () => {
   const wrapper = mount(<HiddenInput { ...props }/>)
   expect(wrapper.find('div').first().props().style).toHaveProperty('position', 'absolute')
   expect(wrapper.find('div').first().props().style).toHaveProperty('left', -9999)
-})
-
-test('HiddenInput is removed from the natural tab order', () => {
-  const wrapper = mount(<HiddenInput { ...props } />)
-  expect(wrapper.find('input').first().prop('tabIndex')).toEqual("-1")
+  expect(wrapper.find('div').first().props().style).toHaveProperty('visibility', 'hidden')
 })


### PR DESCRIPTION
Resolves #328 

This came up during my testing for creating accessible error labels