### PR TITLE
Add esmodule support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@launchpadlab/babel-preset/react"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib
+esm
 /log/*
 /tmp/*
 !/log/.keep

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "presets": [
+    ["@launchpadlab/babel-preset/react", {
+      "env": {
+        // Don't transform modules in "esm" mode.
+        "modules": process.env.BABEL_ENV === 'esm' ? false : 'auto'
+      }
+    }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "description": "Our Components",
   "main": "lib/index.js",
+  "module": "esm/index.js",
+  "sideEffects": false,
   "repository": "launchpadlab/lp-components",
   "homepage": "https://github.com/launchpadlab/lp-components",
   "author": {
@@ -15,8 +17,10 @@
   "license": "MIT",
   "scripts": {
     "start": "yarn run build:development",
-    "build": "babel src --out-dir lib",
-    "build:development": "babel src --watch --out-dir lib",
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "babel src --out-dir lib",
+    "build:esm": "BABEL_ENV=esm babel src --out-dir esm",
+    "build:development": "BABEL_ENV=esm babel src --watch --out-dir esm",
     "clean": "rimraf lib",
     "docs": "documentation build src/index.js -f md -o docs.md",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "engines": {
     "node": "^8.0.0 || ^10.13.0"
   },


### PR DESCRIPTION
Which will enable tree shaking out of the box for all webpack projects, no babel transforms required! 🤩Maintains support for commonjs even though I don't think we've ever used it.

Credit goes to [Material UI](https://material-ui.com/guides/minimizing-bundle-size/) for showing me how to do this.