### PR TITLE
Modify file input markup to allow for focus styling

### DIFF
--- a/.storybook/styles/components/_forms.scss
+++ b/.storybook/styles/components/_forms.scss
@@ -267,31 +267,32 @@ Uploader
     }
   }
 
-  .button-secondary-light span{
+  .button-secondary-light{
     overflow: hidden;
     position: relative;
-    background-color: $grey-base;
-    box-shadow: none;
-    border: none;
-    cursor: pointer;
-    color: $white-base;
-    text-align: center;
-    display: block;
-    @include rem(padding, 20px 0px);
-    color: $black-base;
 
-    &:hover{
-      background-color: darken($grey-base, 8%);
+    span{
+      background-color: $grey-base;
+      cursor: pointer;
+      color: $white-base;
+      text-align: center;
+      display: block;
+      @include rem(padding, 20px 0px);
+      color: $black-base;
+
+      &:hover{
+        background-color: darken($grey-base, 8%);
+      }
+
+      &.fileupload-exists{
+        color: $white-base;
+      }
     }
 
     &.fileupload-exists{
-      color: $white-base;
-    }
-  }
-
-  &.fileupload-exists{
-    div{
-      padding: 0px !important;
+      div{
+        padding: 0px !important;
+      }
     }
   }
 

--- a/.storybook/styles/components/_forms.scss
+++ b/.storybook/styles/components/_forms.scss
@@ -301,7 +301,7 @@ Uploader
     }
   }
 
-  .button-secondary-light>input{
+  input[type="file"]{
     position:absolute;
     top:0;
     right:0;
@@ -310,6 +310,18 @@ Uploader
     filter:alpha(opacity=0);
     transform:translate(-300px, 0) scale(4);
     cursor: pointer;
+
+    &:focus + .button-secondary-light{
+      outline-width: 2px;
+      outline-style: solid;
+      outline-color: Highlight;
+
+      /* WebKit gets its native focus styles. */
+      @media (-webkit-min-device-pixel-ratio:0){
+        outline-color: -webkit-focus-ring-color;
+        outline-style: auto;
+      }
+    }
   }
 }
 

--- a/.storybook/styles/components/_forms.scss
+++ b/.storybook/styles/components/_forms.scss
@@ -267,22 +267,24 @@ Uploader
     }
   }
 
-  .button-secondary-light{
+  .button-secondary-light span{
     overflow: hidden;
     position: relative;
-    vertical-align: middle;
     background-color: $grey-base;
     box-shadow: none;
     border: none;
     cursor: pointer;
     color: $white-base;
     text-align: center;
+    display: block;
+    @include rem(padding, 20px 0px);
+    color: $black-base;
 
     &:hover{
       background-color: darken($grey-base, 8%);
     }
 
-    .fileupload-exists{
+    &.fileupload-exists{
       color: $white-base;
     }
   }
@@ -290,18 +292,10 @@ Uploader
   &.fileupload-exists{
     div{
       padding: 0px !important;
-
-      span{
-        //border: 1px solid $grey-base;
-        display: inline-block;
-        //@include rem(padding, 15px);
-        @include rem(margin, 20px 0px);
-        color: $black-base;
-      }
     }
   }
 
-  input[type="file"]{
+  .button-secondary-light>input{
     position:absolute;
     top:0;
     right:0;
@@ -311,7 +305,7 @@ Uploader
     transform:translate(-300px, 0) scale(4);
     cursor: pointer;
 
-    &:focus + .button-secondary-light{
+    &:focus + span{
       outline-width: 2px;
       outline-style: solid;
       outline-color: Highlight;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },
@@ -59,6 +59,7 @@
     "@babel/polyfill": "^7.4.3",
     "@launchpadlab/babel-preset": "^2.1.0",
     "@launchpadlab/eslint-config": "^2.4.1",
+    "@launchpadlab/prettier-config": "^1.0.0",
     "@size-limit/preset-small-lib": "^3.0.0",
     "@storybook/addon-a11y": "^5.2.5",
     "@storybook/addon-actions": "^5.0.6",
@@ -96,5 +97,9 @@
   },
   "husky": {
     "pre-commit": "yarn run docs && git add docs.md"
+  },
+  "prettier": "@launchpadlab/prettier-config",
+  "jest": {
+    "verbose": "false"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@babel/polyfill": "^7.4.3",
     "@launchpadlab/babel-preset": "^2.1.0",
     "@launchpadlab/eslint-config": "^2.4.1",
-    "@launchpadlab/prettier-config": "^1.0.0",
     "@size-limit/preset-small-lib": "^3.0.0",
     "@storybook/addon-a11y": "^5.2.5",
     "@storybook/addon-actions": "^5.0.6",
@@ -97,9 +96,5 @@
   },
   "husky": {
     "pre-commit": "yarn run docs && git add docs.md"
-  },
-  "prettier": "@launchpadlab/prettier-config",
-  "jest": {
-    "verbose": "false"
   }
 }

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -5,6 +5,7 @@ import { LabeledField } from '../../labels'
 import FilePreview from './file-preview'
 import ImagePreview from './image-preview'
 import { noop, generateInputErrorId, isServer } from '../../../utils'
+import classnames from 'classnames'
 
 /**
  *
@@ -114,22 +115,29 @@ class FileInput extends React.Component {
     return (
       <LabeledField { ...this.props }>
         <div className="fileupload fileupload-exists">
-          { 
-            !hidePreview &&
-            renderPreview({ file, value, ...rest })
-          }
-          <div className={ wrapperClass }>
-            <span className="fileupload-exists"> Select File </span>
-              <input 
-                {...{
-                  id: name,
-                  name,
-                  type: 'file',
-                  onChange: this.loadFile,
-                  accept,
-                  'aria-describedby': hasInputError(meta) ? generateInputErrorId(name) : null,
-                }}
-              />
+          {!hidePreview && renderPreview({ file, value, ...rest })}
+          <div>
+            <input
+              {...{
+                id: name,
+                name,
+                type: 'file',
+                onChange: this.loadFile,
+                accept,
+                'aria-labelledby': name + '-label',
+                'aria-describedby': hasInputError(meta)
+                  ? generateInputErrorId(name)
+                  : null,
+              }}
+            />
+            {/* Include after input to allowing for styling with adjacent sibling selector */}
+            <span
+              className={classnames('fileupload-exists', wrapperClass)}
+              id={name + '-label'}
+            >
+              {' '}
+              Select File{' '}
+            </span>
           </div>
         </div>
       </LabeledField>

--- a/src/forms/inputs/file-input/file-input.js
+++ b/src/forms/inputs/file-input/file-input.js
@@ -5,7 +5,6 @@ import { LabeledField } from '../../labels'
 import FilePreview from './file-preview'
 import ImagePreview from './image-preview'
 import { noop, generateInputErrorId, isServer } from '../../../utils'
-import classnames from 'classnames'
 
 /**
  *
@@ -116,7 +115,7 @@ class FileInput extends React.Component {
       <LabeledField { ...this.props }>
         <div className="fileupload fileupload-exists">
           {!hidePreview && renderPreview({ file, value, ...rest })}
-          <div>
+          <div className={wrapperClass}>
             <input
               {...{
                 id: name,
@@ -131,13 +130,7 @@ class FileInput extends React.Component {
               }}
             />
             {/* Include after input to allowing for styling with adjacent sibling selector */}
-            <span
-              className={classnames('fileupload-exists', wrapperClass)}
-              id={name + '-label'}
-            >
-              {' '}
-              Select File{' '}
-            </span>
+            <span className='fileupload-exists' id={name + '-label'}> Select File </span>
           </div>
         </div>
       </LabeledField>


### PR DESCRIPTION
Enables focus styling on the `span` (when focusing on the `input`) by moving it after the `input`, which allows for the use of adjacent sibling css selector (`+`).

## Author Checklist

- [x] Add unit test(s)
    - I attempted to add one to check for a style change, but doesn't look like there's a good way to grab non-inline styles applied by external css files. Open to any ideas on how to apply a test here!
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/npm-package-guidelines.md#pull-requests-and-deployments))
    - Would you consider this a patch or minor update?
- [x] Update documentation (if necessary)
    - Should anything be updated to mention adding adjacent sibling focus styles? I haven't seen that kind of documentation mentioned for other components.
- [x] Add story to storybook (if necessary)
- [x] Assign dev reviewer
