### PR TITLE
fix(sortable table): allow arbitrary table props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.1.1",
+  "version": "5.2.1",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },

--- a/src/tables/sortable-table.js
+++ b/src/tables/sortable-table.js
@@ -92,6 +92,7 @@ function SortableTable({
   onChange,
   rowComponent,
   headerComponent,
+  ...rest
 }) {
   const columns = getColumnData(children, disableSort)
   const { initialSortPath, initialSortFunc, initialValueGetter } =
@@ -147,7 +148,7 @@ function SortableTable({
   }
 
   return (
-    <table className={classnames(className, { 'sortable-table': !disableSort })}>
+    <table className={classnames(className, { 'sortable-table': !disableSort })} {...rest}>
       <thead><tr>
         {
           columns.map((column, key) => {

--- a/src/tables/sortable-table.js
+++ b/src/tables/sortable-table.js
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { getColumnData, Types } from './helpers'
 import { TableHeader as DefaultHeader, TableRow as Row } from './components'
-import { get, noop, orderBy } from '../utils'
+import { filterInvalidDOMProps, get, noop, orderBy } from '../utils'
 import classnames from 'classnames'
 
 /**
@@ -148,24 +148,24 @@ function SortableTable({
   }
 
   return (
-    <table className={classnames(className, { 'sortable-table': !disableSort })} {...rest}>
-      <thead><tr>
-        {
-          columns.map((column, key) => {
-            const Header = column.headerComponent || headerComponent || DefaultHeader
-            return (
-              <Header {...{
-                key,
-                column,
-                sortPath,
-                ascending,
-                onClick: () => handleColumnChange(column)
-              }} />
-            )
-          }
-          )
-        }
-      </tr></thead>
+    <table className={classnames(className, { 'sortable-table': !disableSort })} {...filterInvalidDOMProps(rest)}>
+      <thead>
+        <tr>
+          {columns.map((column, key) => {
+              const Header = column.headerComponent || headerComponent || DefaultHeader
+              return (
+                <Header {...{
+                  key,
+                  column,
+                  sortPath,
+                  ascending,
+                  onClick: () => handleColumnChange(column)
+                }} />
+              )
+            }
+          )}
+        </tr>
+      </thead>
       <tbody>
         {
           data.map((rowData, key) =>

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -335,3 +335,12 @@ test('table data is updated when data prop changes', () => {
   wrapper.setProps({ data: newTableData })
   expect(wrapper.find('td').first().text()).toEqual('Kortney')
 })
+
+test('arbitrary props passed to table element', () => {
+  const wrapper = mount(
+    <SortableTable data={tableData} aria-label="Annual Report">
+      <Column name="name" />
+    </SortableTable>
+  )
+  expect(wrapper.find('table').first().props()['aria-label']).toEqual('Annual Report')
+})

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -342,5 +342,14 @@ test('arbitrary props passed to table element', () => {
       <Column name="name" />
     </SortableTable>
   )
-  expect(wrapper.find('table').first().props()['aria-label']).toEqual('Annual Report')
+  expect(wrapper.find('table').first().prop('aria-label')).toEqual('Annual Report')
+})
+
+test('invalid arbitrary props filtered out', () => {
+  const wrapper = mount(
+    <SortableTable data={tableData} aria-label="Annual Report" invalidProp="shouldFail">
+      <Column name="name" />
+    </SortableTable>
+  )
+  expect(wrapper.find('table').first().prop('invalidProp')).toBe(undefined)
 })


### PR DESCRIPTION
* Pass props not used by the SortableTable component through to the underlying <table> element
* Add test to verify the new behavior

Resolves: https://github.com/LaunchPadLab/lp-components/issues/324

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [ ] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [x] Assign dev reviewer
