### PR TITLE
Row component props

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1390,7 +1390,7 @@ This component's behavior is largely determined by the [TableColumn][107] compon
 -   `disableSort` **[Boolean][151]** A flag to disable sorting on all columns and hide sorting arrows. (optional, default `false`)
 -   `controlled` **[Boolean][151]** A flag to disable sorting on all columns, while keeping the sorting arrows. Used when sorting is controlled by an external source. (optional, default `false`)
 -   `onChange` **[Function][150]?** A callback that will be fired when the sorting state changes
--   `rowComponent` **[Function][150]?** A custom row component for the table. Will be passed the `data` for the row, as well as `children` to render.
+-   `rowComponent` **[Function][150]?** A custom row component for the table. Will be passed the `data` for the row, several internal table states (the current column being sorted (sortPath), whether ascending sort is active or not (ascending), the sorting function (sortFunc), and the value getter (valueGetter)) as well as `children` to render.
 -   `headerComponent` **[Function][150]?** A custom header component for the table. Will be passed the configuration of the corresponding column, as well as the current `sortPath` / `ascending` and an `onClick` handler. May be overridden by a custom `headerComponent` for a column.
 
 ### Examples

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.1.1",
+  "version": "5.3.0",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },

--- a/src/tables/components/table-row.js
+++ b/src/tables/components/table-row.js
@@ -7,6 +7,10 @@ const propTypes = {
   columns: PropTypes.arrayOf(Types.column).isRequired,
   rowComponent: Types.component,
   rowData: PropTypes.any,
+  ascending: PropTypes.bool,
+  sortPath: PropTypes.string,
+  sortFunc: PropTypes.func,
+  valueGetter: PropTypes.func,
 }
 
 const DefaultRowComponent = ({ children }) => <tr>{ children }</tr> // eslint-disable-line
@@ -17,9 +21,13 @@ function TableRow ({
   columns,
   rowComponent: RowComponent = DefaultRowComponent,
   rowData,
+  ascending,
+  sortPath,
+  sortFunc,
+  valueGetter,
 }) {
   return (
-    <RowComponent { ...{ data: rowData } }>
+    <RowComponent { ...{ data: rowData, ascending, sortPath, sortFunc, valueGetter } }>
       {
         columns.map((column, key) => {
           const { name, component: CellComponent=DefaultCellComponent, format=identity, onClick=noop, valueGetter, ...rest } = column

--- a/src/tables/sortable-table.js
+++ b/src/tables/sortable-table.js
@@ -18,7 +18,7 @@ import classnames from 'classnames'
  * @param {Boolean} [disableSort=false] - A flag to disable sorting on all columns and hide sorting arrows.
  * @param {Boolean} [controlled=false] - A flag to disable sorting on all columns, while keeping the sorting arrows. Used when sorting is controlled by an external source.
  * @param {Function} [onChange] - A callback that will be fired when the sorting state changes
- * @param {Function} [rowComponent] - A custom row component for the table. Will be passed the `data` for the row, as well as `children` to render.
+ * @param {Function} [rowComponent] - A custom row component for the table. Will be passed the `data` for the row, several internal table states (the current column being sorted (sortPath), whether ascending sort is active or not (ascending), the sorting function (sortFunc), and the value getter (valueGetter)) as well as `children` to render.
  * @param {Function} [headerComponent] - A custom header component for the table. Will be passed the configuration of the corresponding column, as well as the current `sortPath` / `ascending` and an `onClick` handler. May be overridden by a custom `headerComponent` for a column.
  * @example
  *
@@ -173,6 +173,10 @@ function SortableTable({
               rowData,
               columns,
               rowComponent,
+              ascending,
+              sortPath,
+              sortFunc,
+              valueGetter,
             }} />
           )
         }

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -151,15 +151,29 @@ test('column can have custom cell component', () => {
   expect(wrapper.find(MyCell).first().props()).toMatchObject(expectedProps)
 })
 
-test('column can have custom row component', () => {
+test('table can have custom row component initialized with table state props', () => {
   const MyRow = ({ children }) => <tr>{children}</tr> // eslint-disable-line
+  const mySort = jest.fn(compareAtPath('name', sortAscending))
+  const myValueGetter = jest.fn((data) => data.name.toUpperCase())
   const wrapper = mount(
-    <SortableTable data={tableData} rowComponent={MyRow}>
-      <Column name="name" />
+    <SortableTable
+      data={tableData}
+      rowComponent={MyRow}
+      initialAscending={false}
+      initialColumn={'name'}
+    >
+      <Column name="name" sortFunc={mySort} valueGetter={myValueGetter} />
     </SortableTable>
   )
   expect(wrapper.find(MyRow).exists()).toBe(true)
-  expect(wrapper.find(MyRow).first().props().data).toEqual({ name: 'Kim', test: true })
+  const expectedProps = {
+    data: { name: 'Tommy'},
+    ascending: false,
+    sortPath: 'name',
+    sortFunc: mySort,
+    valueGetter: myValueGetter,
+  }
+  expect(wrapper.find(MyRow).first().props()).toMatchObject(expectedProps)
 })
 
 test('column can have custom header component', () => {


### PR DESCRIPTION
Resolves issue: https://github.com/LaunchPadLab/lp-components/issues/307

This PR provides the following table state values to the user-defined `RowComponent`:

- ascending
- sortPath
- sortFunc
- valueGetter

Developers may use these additional state values to enhance the functionality of their customer `RowComponent`.

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [x] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [x] Assign dev reviewer
