### PR TITLE
Textarea Ref Forwarding

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -942,7 +942,7 @@ export default CoolPersonForm
 
 ## Textarea
 
-A textarea input that can be used in a `redux-forms`-controlled form. Optionally displays a character count.
+A textarea input that can be used in a `redux-forms`-controlled form. Forwards ref down to textarea input and optionally displays a character count.
 
 ### Parameters
 
@@ -950,6 +950,7 @@ A textarea input that can be used in a `redux-forms`-controlled form. Optionally
 -   `meta` **[Object][156]** A `redux-forms` [meta][158] object
 -   `maxLength` **[Number][153]?** The maximum allowed length of the input
 -   `hideCharacterCount` **[Boolean][151]** Whether to hide the character count if given a maxLength (optional, default `false`)
+-   `forwardedRef` **[Ref][178]?** A ref to be forwarded to `textarea` input when used with `redux-forms`
 
 ### Examples
 
@@ -2131,3 +2132,5 @@ function MyView () {
 [176]: https://github.com/reactjs/react-modal
 
 [177]: https://github.com/reactjs/react-modal/issues/25
+
+[178]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/docs.md
+++ b/docs.md
@@ -950,7 +950,7 @@ A textarea input that can be used in a `redux-forms`-controlled form. Forwards r
 -   `meta` **[Object][156]** A `redux-forms` [meta][158] object
 -   `maxLength` **[Number][153]?** The maximum allowed length of the input
 -   `hideCharacterCount` **[Boolean][151]** Whether to hide the character count if given a maxLength (optional, default `false`)
--   `forwardedRef` **[Ref][178]?** A ref to be forwarded to `textarea` input when used with `redux-forms`
+-   `forwardedRef` **[Ref][178]?** A ref to be forwarded to `textarea` input when standard `ref` prop cannot be used
 
 ### Examples
 

--- a/docs.md
+++ b/docs.md
@@ -942,7 +942,7 @@ export default CoolPersonForm
 
 ## Textarea
 
-A textarea input that can be used in a `redux-forms`-controlled form. Forwards ref down to textarea input and optionally displays a character count.
+A textarea input that can be used in a `redux-forms`-controlled form. Can forward ref down to textarea input and optionally displays a character count.
 
 ### Parameters
 
@@ -950,7 +950,7 @@ A textarea input that can be used in a `redux-forms`-controlled form. Forwards r
 -   `meta` **[Object][156]** A `redux-forms` [meta][158] object
 -   `maxLength` **[Number][153]?** The maximum allowed length of the input
 -   `hideCharacterCount` **[Boolean][151]** Whether to hide the character count if given a maxLength (optional, default `false`)
--   `forwardedRef` **[Ref][178]?** A ref to be forwarded to `textarea` input when standard `ref` prop cannot be used
+-   `forwardedRef` **[Ref][178]?** A ref to be forwarded to `textarea` input (standard `ref` cannot currently be forwarded)
 
 ### Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },

--- a/src/forms/helpers/blur-dirty.js
+++ b/src/forms/helpers/blur-dirty.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { wrapDisplayName, noop, set, omit } from '../../utils'
 
@@ -36,7 +36,7 @@ import { wrapDisplayName, noop, set, omit } from '../../utils'
 
 function blurDirty () {
   return Wrapped => {
-    function Wrapper (props) {
+    const Wrapper = forwardRef(function Wrapper(props, ref) {
       const {
         meta: { pristine },
         alwaysBlur,
@@ -44,9 +44,9 @@ function blurDirty () {
       const disableBlur = (pristine && !alwaysBlur)
       const passedProps = disableBlur ? set('input.onBlur', noop, props) : props
       return (
-        <Wrapped { ...omit('alwaysBlur', passedProps) } />
+        <Wrapped { ...omit('alwaysBlur', passedProps) } ref={ref} />
       )
-    }
+    })
     Wrapper.displayName = wrapDisplayName(Wrapped, 'blurDirty')
     Wrapper.propTypes = {
       alwaysBlur: PropTypes.bool,

--- a/src/forms/helpers/blur-dirty.js
+++ b/src/forms/helpers/blur-dirty.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { wrapDisplayName, noop, set, omit } from '../../utils'
 
@@ -36,7 +36,7 @@ import { wrapDisplayName, noop, set, omit } from '../../utils'
 
 function blurDirty () {
   return Wrapped => {
-    const Wrapper = forwardRef(function Wrapper(props, ref) {
+    function Wrapper (props) {
       const {
         meta: { pristine },
         alwaysBlur,
@@ -44,9 +44,9 @@ function blurDirty () {
       const disableBlur = (pristine && !alwaysBlur)
       const passedProps = disableBlur ? set('input.onBlur', noop, props) : props
       return (
-        <Wrapped { ...omit('alwaysBlur', passedProps) } ref={ref} />
+        <Wrapped { ...omit('alwaysBlur', passedProps) } />
       )
-    })
+    }
     Wrapper.displayName = wrapDisplayName(Wrapped, 'blurDirty')
     Wrapper.propTypes = {
       alwaysBlur: PropTypes.bool,

--- a/src/forms/inputs/textarea.js
+++ b/src/forms/inputs/textarea.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {forwardRef} from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { blurDirty, fieldPropTypes, hasInputError, omitLabelProps } from '../helpers'
@@ -7,7 +7,8 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
 
 /**
  *
- * A textarea input that can be used in a `redux-forms`-controlled form. Optionally displays a character count.
+ * A textarea input that can be used in a `redux-forms`-controlled form.
+ * Forwards ref down to textarea input and optionally displays a character count.
  *
  * @name Textarea
  * @type Function
@@ -15,6 +16,7 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
  * @param {Number} [maxLength] - The maximum allowed length of the input
  * @param {Boolean} [hideCharacterCount=false] - Whether to hide the character count if given a maxLength
+ * @param {Ref} [forwardedRef] - A ref to be forwarded to `textarea` input when used with `redux-forms`
  * @example
  *
  * function BiographyForm ({ handleSubmit, pristine, invalid, submitting }) {
@@ -36,21 +38,29 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
 const propTypes = {
   ...fieldPropTypes,
   hideCharacterCount: PropTypes.bool,
-  maxLength: PropTypes.oneOfType([PropTypes.number, PropTypes.bool])
+  maxLength: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.instanceOf(Element), // eslint-disable-line no-undef
+    }),
+  ]),
 }
 
 const defaultProps = {
   maxLength: null,
   hideCharacterCount: false,
+  forwardedRef: null,
 }
 
-function Textarea (props) {
+const Textarea = forwardRef(function Textarea (props, ref) {
   const {
     input: { name, value, onBlur, onChange },
     meta, // eslint-disable-line no-unused-vars
     hideCharacterCount,
     className,
     maxLength,
+    forwardedRef,
     ...rest
   } = omitLabelProps(props)
   return (
@@ -72,16 +82,16 @@ function Textarea (props) {
           value,
           onBlur,
           onChange,
+          ref: forwardedRef || ref,
           'aria-describedby': hasInputError(meta) ? generateInputErrorId(name) : null,
           ...filterInvalidDOMProps(rest),
         }}
       />
     </LabeledField>
   )
-}
+})
 
 Textarea.propTypes = propTypes
-
 Textarea.defaultProps = defaultProps
 
 export default compose(

--- a/src/forms/inputs/textarea.js
+++ b/src/forms/inputs/textarea.js
@@ -1,4 +1,4 @@
-import React, {forwardRef} from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { blurDirty, fieldPropTypes, hasInputError, omitLabelProps } from '../helpers'
@@ -16,7 +16,7 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
  * @param {Number} [maxLength] - The maximum allowed length of the input
  * @param {Boolean} [hideCharacterCount=false] - Whether to hide the character count if given a maxLength
- * @param {Ref} [forwardedRef] - A ref to be forwarded to `textarea` input when used with `redux-forms`
+ * @param {Ref} [forwardedRef] - A ref to be forwarded to `textarea` input when standard `ref` prop cannot be used
  * @example
  *
  * function BiographyForm ({ handleSubmit, pristine, invalid, submitting }) {
@@ -42,7 +42,8 @@ const propTypes = {
   forwardedRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({
-      current: PropTypes.instanceOf(Element), // eslint-disable-line no-undef
+      // eslint-disable-next-line no-undef
+      current: PropTypes.instanceOf(Element),
     }),
   ]),
 }
@@ -56,7 +57,7 @@ const defaultProps = {
 const Textarea = forwardRef(function Textarea (props, ref) {
   const {
     input: { name, value, onBlur, onChange },
-    meta, // eslint-disable-line no-unused-vars
+    meta,
     hideCharacterCount,
     className,
     maxLength,

--- a/src/forms/inputs/textarea.js
+++ b/src/forms/inputs/textarea.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { blurDirty, fieldPropTypes, hasInputError, omitLabelProps } from '../helpers'
@@ -8,7 +8,7 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
 /**
  *
  * A textarea input that can be used in a `redux-forms`-controlled form.
- * Forwards ref down to textarea input and optionally displays a character count.
+ * Can forward ref down to textarea input and optionally displays a character count.
  *
  * @name Textarea
  * @type Function
@@ -16,7 +16,7 @@ import { compose, filterInvalidDOMProps, generateInputErrorId } from '../../util
  * @param {Object} meta - A `redux-forms` [meta](http://redux-form.com/6.5.0/docs/api/Field.md/#meta-props) object
  * @param {Number} [maxLength] - The maximum allowed length of the input
  * @param {Boolean} [hideCharacterCount=false] - Whether to hide the character count if given a maxLength
- * @param {Ref} [forwardedRef] - A ref to be forwarded to `textarea` input when standard `ref` prop cannot be used
+ * @param {Ref} [forwardedRef] - A ref to be forwarded to `textarea` input (standard `ref` cannot currently be forwarded)
  * @example
  *
  * function BiographyForm ({ handleSubmit, pristine, invalid, submitting }) {
@@ -54,7 +54,7 @@ const defaultProps = {
   forwardedRef: null,
 }
 
-const Textarea = forwardRef(function Textarea (props, ref) {
+function Textarea (props) {
   const {
     input: { name, value, onBlur, onChange },
     meta,
@@ -83,14 +83,14 @@ const Textarea = forwardRef(function Textarea (props, ref) {
           value,
           onBlur,
           onChange,
-          ref: forwardedRef || ref,
+          ref: forwardedRef,
           'aria-describedby': hasInputError(meta) ? generateInputErrorId(name) : null,
           ...filterInvalidDOMProps(rest),
         }}
       />
     </LabeledField>
   )
-})
+}
 
 Textarea.propTypes = propTypes
 Textarea.defaultProps = defaultProps

--- a/stories/forms/inputs/textarea-story.js
+++ b/stories/forms/inputs/textarea-story.js
@@ -1,4 +1,4 @@
-import React, {createRef} from 'react'
+import React, { createRef } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Textarea as StaticTextarea } from 'src'

--- a/stories/forms/inputs/textarea-story.js
+++ b/stories/forms/inputs/textarea-story.js
@@ -38,13 +38,6 @@ storiesOf('Textarea', module)
       hideCharacterCount={true}
     />
   ))
-  .add('with a standard ref', () => (
-    <Textarea
-      input={inputProps}
-      meta={{}}
-      ref={inputRef}
-    />
-  ))
   .add('with a forwardedRef', () => (
     <Textarea
       input={inputProps}

--- a/stories/forms/inputs/textarea-story.js
+++ b/stories/forms/inputs/textarea-story.js
@@ -38,6 +38,13 @@ storiesOf('Textarea', module)
       hideCharacterCount={true}
     />
   ))
+  .add('with a standard ref', () => (
+    <Textarea
+      input={inputProps}
+      meta={{}}
+      ref={inputRef}
+    />
+  ))
   .add('with a forwardedRef', () => (
     <Textarea
       input={inputProps}

--- a/stories/forms/inputs/textarea-story.js
+++ b/stories/forms/inputs/textarea-story.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {createRef} from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Textarea as StaticTextarea } from 'src'
@@ -13,6 +13,8 @@ const inputProps = {
   name: 'person.biography',
   onChange: action('text area changed')
 }
+
+const inputRef = createRef()
 
 storiesOf('Textarea', module)
   .add('default', () => (
@@ -34,5 +36,12 @@ storiesOf('Textarea', module)
       meta={{}}
       maxLength={50}
       hideCharacterCount={true}
+    />
+  ))
+  .add('with a forwardedRef', () => (
+    <Textarea
+      input={inputProps}
+      meta={{}}
+      forwardedRef={inputRef}
     />
   ))

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createRef } from 'react'
 import { mount } from 'enzyme'
 import { Textarea } from '../../../src/'
 
@@ -10,7 +10,7 @@ test('Textarea passes down defaults and does not show character count', () => {
     },
     meta: {},
   }
-  const wrapper = mount(<Textarea { ...props }/>)
+  const wrapper = mount(<Textarea {...props} />)
   expect(wrapper.find('textarea').prop('maxLength')).toEqual(null)
   expect(wrapper.find('.character-count').exists()).toEqual(false)
 })
@@ -24,7 +24,7 @@ test('Textarea passes down max length and shows character count correctly', () =
     meta: {},
     maxLength: 5,
   }
-  const wrapper = mount(<Textarea { ...props }/>)
+  const wrapper = mount(<Textarea {...props} />)
   expect(wrapper.find('textarea').prop('maxLength')).toEqual(5)
   expect(wrapper.find('.character-count').exists()).toEqual(true)
 })
@@ -39,7 +39,7 @@ test('Textarea hides character count correctly', () => {
     maxLength: 5,
     hideCharacterCount: true,
   }
-  const wrapper = mount(<Textarea { ...props }/>)
+  const wrapper = mount(<Textarea {...props} />)
   expect(wrapper.find('textarea').prop('maxLength')).toEqual(5)
   expect(wrapper.find('.character-count').exists()).toEqual(false)
 })
@@ -58,11 +58,11 @@ test('Textarea is given an aria-describedby attribute when there is an input err
     maxLength: 5,
     hideCharacterCount: true,
   }
-  const wrapper = mount(<Textarea { ...props }/>)
+  const wrapper = mount(<Textarea {...props} />)
   expect(wrapper.find('textarea').prop('aria-describedby')).toContain(name)
 })
 
-test('Textrea does not receive invalid dom attributes', () => {
+test('Textarea does not receive invalid dom attributes', () => {
   const name = 'test'
   const props = {
     input: {
@@ -72,9 +72,24 @@ test('Textrea does not receive invalid dom attributes', () => {
     meta: {},
     maxLength: 5,
     hideCharacterCount: true,
-    onClickLabel: () => 'foo'
+    onClickLabel: () => 'foo',
   }
-  
+
   const wrapper = mount(<Textarea {...props} />)
   expect(wrapper.find('textarea').prop('onClickLabel')).toBe(undefined)
+})
+
+test('Textarea passes down forwardedRef to input correctly', () => {
+  const inputRef = createRef()
+  const props = {
+    input: {
+      name: 'test',
+      value: '',
+    },
+    meta: {},
+    forwardedRef: inputRef,
+  }
+
+  const wrapper = mount(<Textarea {...props} />)
+  expect(wrapper.find('textarea').prop('id')).toEqual(inputRef.current.id)
 })

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -79,6 +79,21 @@ test('Textarea does not receive invalid dom attributes', () => {
   expect(wrapper.find('textarea').prop('onClickLabel')).toBe(undefined)
 })
 
+test('Textarea passes down standard ref to input correctly', () => {
+  const inputRef = createRef()
+  const props = {
+    input: {
+      name: 'test',
+      value: '',
+    },
+    meta: {},
+    ref: inputRef,
+  }
+
+  const wrapper = mount(<Textarea {...props} />)
+  expect(wrapper.find('textarea').prop('id')).toEqual(inputRef.current.id)
+})
+
 test('Textarea passes down forwardedRef to input correctly', () => {
   const inputRef = createRef()
   const props = {

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -79,21 +79,6 @@ test('Textarea does not receive invalid dom attributes', () => {
   expect(wrapper.find('textarea').prop('onClickLabel')).toBe(undefined)
 })
 
-test('Textarea passes down standard ref to input correctly', () => {
-  const inputRef = createRef()
-  const props = {
-    input: {
-      name: 'test',
-      value: '',
-    },
-    meta: {},
-    ref: inputRef,
-  }
-
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('id')).toEqual(inputRef.current.id)
-})
-
 test('Textarea passes down forwardedRef to input correctly', () => {
   const inputRef = createRef()
   const props = {


### PR DESCRIPTION
<!-- Include description and link to resolved issue(s) here. -->
Resolved Issue: https://github.com/LaunchPadLab/lp-components/issues/470
Description: Allows for a ref to be provided (through a new `forwardedRef` prop) on `Textarea` that will be passed down to the inner `textarea` input.

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [x] Update documentation (if necessary)
- [x] Add story to storybook (if necessary)
- [x] Assign dev reviewer
