### PR TITLE
Upgrade to stack version 20

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,5 +23,6 @@
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "stack": "heroku-20"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "engines": {
     "node": "^8.0.0 || ^10.13.0 || ^12.0.0"
   },


### PR DESCRIPTION
<!-- Include description and link to resolved issue(s) here. -->
Heroku builds no longer succeed:
```
This app is using the Cedar-14 stack, which has been end-of-life since May 1st 2019. The building of Cedar-14 apps is no longer supported as of November 2nd 2020.
```
Setting the latest stack (version 20 currently) will need to be completed on the Production app in Heroku, but the change made here will allow us to test that nothing breaks using the Review App (this change will also need to be merged in to `ensure that your Review Apps and Heroku CI runs use the same stack`).

Details here: https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack

## Author Checklist

- [ ] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [ ] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [x] Assign dev reviewer
