### PR TITLE
Update docs.md for SortableTable

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1418,7 +1418,16 @@ A component used to pass column information to a [Table][101] or [SortableTable]
 -   `label` **[String][149]?** The text that will be displayed in the column header. Defaults to `name`.
 -   `sortFunc` **[Function][150]?** The function that will be used to sort the table data when the column is selected
 -   `component` **[Function][150]?** A custom cell component for the column. Will be passed the `key`, `name`, `value` and `data` for the row.
--   `headerComponent` **[Function][150]?** A custom header component for the column. Will be passed the configuration of the column, as well as the current `sortPath` / `ascending` and an `onClick` handler.
+-   `headerComponent` **[Function][150]?** A custom header component for the column. Will be passed the configuration of the column, as well as the current `sortPath` / `ascending` and an `onClick` handler. Be sure to pass the onClick handler to your CustomHeader in order to maintain sorting functionality.
+
+```javascript
+function CustomHeader({ column: { name }, onClick }) {
+  return (
+    <th onClick={onClick}>{name.toUpperCase() + '!'}</th>
+  )
+}
+```
+
 -   `onClick` **[Function][150]?** A function that will be called `onClick` on every cell in the column
 -   `format` **[Function][150]?** A function that formats the value displayed in each cell in the column
 -   `disabled` **[Boolean][151]?** A flag that disables sorting for the column


### PR DESCRIPTION
Adding specific documentation regarding passing of onClick handler to CustomHeader. Also fixed the Storybook component to pass onClick.

[SortableTable Custom Header example does not pass down click handler #498](https://github.com/LaunchPadLab/lp-components/issues/498)