### PR TITLE
Add v6 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Documentation and usage info can be found in [docs.md](docs.md).
 - [v3.0.0](migration-guides/v3.0.0.md)
 - [v4.0.0](migration-guides/v4.0.0.md)
 - [v5.0.0](migration-guides/v5.0.0.md)
+- [v6.0.0](migration-guides/v6.0.0.md)
 
 ## Contribution
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "engines": {
     "node": "^14.19 || ^16.14"
   },


### PR DESCRIPTION
Adds link to the v6 migration guide in the main README

## Author Checklist

- [X] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
