### PR TITLE
Compile assets before publishing (npm v8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "engines": {
     "node": "^14.19 || ^16.14"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clean": "rm -rf lib esm",
     "docs": "documentation build src/index.js -f md -o docs.md",
     "lint": "eslint src --max-warnings=0",
-    "prepublish": "yarn run clean && yarn run build",
+    "prepublishOnly": "yarn run clean && yarn run build",
     "storybook": "yarn && start-storybook -p 6006",
     "test": "jest --coverage",
     "size": "yarn build && size-limit",


### PR DESCRIPTION
`prepublish` doesn't run on publish for npm versions >= 7. With the switch to node 16 in #543, npm was upgraded from 6 to 8. This means that the prior versions of `lp-components@v6` have an outdated build directory (i.e., aren't serving the right assets)

## Author Checklist

- [ ] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [ ] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [ ] Assign dev reviewer
