### PR TITLE
Enable passage of props when using custom `rowComponent` with SortableTable/Table

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1410,6 +1410,7 @@ This component's behavior is largely determined by the [TableColumn][103] compon
 *   `controlled` **[Boolean][144]** A flag to disable sorting on all columns, while keeping the sorting arrows. Used when sorting is controlled by an external source. (optional, default `false`)
 *   `onChange` **[Function][143]?** A callback that will be fired when the sorting state changes
 *   `rowComponent` **[Function][143]?** A custom row component for the table. Will be passed the `data` for the row, several internal table states (the current column being sorted (sortPath), whether ascending sort is active or not (ascending), the sorting function (sortFunc), and the value getter (valueGetter)) as well as `children` to render.
+*   `rowComponentProps` **[Object][148]?** Additional props to pass to the rowComponent, useful for passing event handlers
 *   `headerComponent` **[Function][143]?** A custom header component for the table. Will be passed the configuration of the corresponding column, as well as the current `sortPath` / `ascending` and an `onClick` handler. May be overridden by a custom `headerComponent` for a column.
 
 ### Examples

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "engines": {
     "node": "^18.12"
   },

--- a/src/tables/components/table-row.js
+++ b/src/tables/components/table-row.js
@@ -6,6 +6,7 @@ import { Types } from '../helpers'
 const propTypes = {
   columns: PropTypes.arrayOf(Types.column).isRequired,
   rowComponent: Types.component,
+  rowComponentProps: PropTypes.object,
   rowData: PropTypes.any,
   ascending: PropTypes.bool,
   sortPath: PropTypes.string,
@@ -25,6 +26,7 @@ const DefaultCellComponent = (
 function TableRow({
   columns,
   rowComponent: RowComponent = DefaultRowComponent,
+  rowComponentProps: rowComponentProps = {},
   rowData,
   ascending,
   sortPath,
@@ -33,7 +35,14 @@ function TableRow({
 }) {
   return (
     <RowComponent
-      {...{ data: rowData, ascending, sortPath, sortFunc, valueGetter }}
+      {...{
+        data: rowData,
+        ascending,
+        sortPath,
+        sortFunc,
+        valueGetter,
+        ...rowComponentProps,
+      }}
     >
       {columns.map((column, key) => {
         const {

--- a/src/tables/sortable-table.js
+++ b/src/tables/sortable-table.js
@@ -19,6 +19,7 @@ import classnames from 'classnames'
  * @param {Boolean} [controlled=false] - A flag to disable sorting on all columns, while keeping the sorting arrows. Used when sorting is controlled by an external source.
  * @param {Function} [onChange] - A callback that will be fired when the sorting state changes
  * @param {Function} [rowComponent] - A custom row component for the table. Will be passed the `data` for the row, several internal table states (the current column being sorted (sortPath), whether ascending sort is active or not (ascending), the sorting function (sortFunc), and the value getter (valueGetter)) as well as `children` to render.
+ * @param {Object} [rowComponentProps] - Additional props to pass to the rowComponent, useful for passing event handlers
  * @param {Function} [headerComponent] - A custom header component for the table. Will be passed the configuration of the corresponding column, as well as the current `sortPath` / `ascending` and an `onClick` handler. May be overridden by a custom `headerComponent` for a column.
  * @example
  *
@@ -46,6 +47,7 @@ const propTypes = {
   controlled: PropTypes.bool,
   onChange: PropTypes.func,
   rowComponent: Types.component,
+  rowComponentProps: PropTypes.object,
   headerComponent: Types.component,
   caption: PropTypes.node,
 }
@@ -57,6 +59,7 @@ const defaultProps = {
   disableReverse: false,
   disableSort: false,
   controlled: false,
+  rowComponentProps: {},
   onChange: noop,
   caption: null,
 }
@@ -92,6 +95,7 @@ function SortableTable({
   controlled,
   onChange,
   rowComponent,
+  rowComponentProps,
   headerComponent,
   caption,
   ...rest
@@ -191,6 +195,7 @@ function SortableTable({
               rowData,
               columns,
               rowComponent,
+              rowComponentProps,
               ascending,
               sortPath,
               sortFunc,

--- a/stories/tables/sortable-table.story.js
+++ b/stories/tables/sortable-table.story.js
@@ -31,8 +31,8 @@ function CustomCellWithRowData({ data: { name, active } }) {
 }
 
 // eslint-disable-next-line react/prop-types
-function CustomRow({ data: { active }, children }) {
-  return <tr style={{ backgroundColor: colorForStatus(active) }}>{children}</tr>
+function CustomRow({ data: { active }, children, onClick }) {
+  return <tr onClick={onClick} style={{ backgroundColor: colorForStatus(active) }}>{children}</tr>
 }
 
 // eslint-disable-next-line react/prop-types
@@ -114,8 +114,8 @@ storiesOf('SortableTable', module)
       <Column name="active" component={CustomCellWithRowData} />
     </SortableTable>
   ))
-  .add('with custom row component', () => (
-    <SortableTable data={tableData} rowComponent={CustomRow}>
+  .add('with custom row component and props', () => (
+    <SortableTable data={tableData} rowComponent={CustomRow} rowComponentProps={{onClick: () => { console.log('Clicked') }}}>
       <Column name="name" />
       <Column name="age" />
       <Column name="active" />

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -154,21 +154,29 @@ test('column can have custom cell component', () => {
   expect(wrapper.find(MyCell).first().props()).toMatchObject(expectedProps)
 })
 
-test('table can have custom row component initialized with table state props', () => {
-  const MyRow = ({ children }) => <tr>{children}</tr> // eslint-disable-line
+test('table can have custom row component initialized with table state props and custom props', () => {
+  const MyRow = ({ children, onClick }) => <tr onClick={onClick}>{children}</tr> // eslint-disable-line
   const mySort = jest.fn(compareAtPath('name', sortAscending))
   const myValueGetter = jest.fn((data) => data.name.toUpperCase())
+  const onRowClickSpy = jest.fn()
   const wrapper = mount(
     <SortableTable
       data={tableData}
       rowComponent={MyRow}
+      rowComponentProps={{ onClick: onRowClickSpy }}
       initialAscending={false}
       initialColumn={'name'}
     >
       <Column name="name" sortFunc={mySort} valueGetter={myValueGetter} />
     </SortableTable>
   )
-  expect(wrapper.find(MyRow).exists()).toBe(true)
+
+  const myRow = wrapper.find(MyRow)
+  expect(myRow.exists()).toBe(true)
+
+  myRow.at(0).simulate('click')
+  expect(onRowClickSpy).toHaveBeenCalled()
+
   const expectedProps = {
     data: { name: 'Tommy' },
     ascending: false,


### PR DESCRIPTION
At the moment, the `SortableTable` and `Table` components allow the passage of a custom `rowComponent`. However, there's no ability to pass additional props to this component from parent/consuming components, as this is presumed to just need the `data`.

In my current project, we're building a rather involved table, and it requires the passage of event handlers to a `rowComponent` from a parent. At the moment, our workaround is to either **a)** create the component in a closure that has access to the event handler, or **b)** force us to manage the state in a grander fashion with either contexts or redux. Neither option is ideal, as we're only passing the handler down through one component, and it occurred to us that this is something that the `lp-components` package could introduce at a very low complexity cost.

## Release Notes

Semver minor bump (new behavior without breaking existing contracts), adding `rowComponentProps`, that get passed to the row component.

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [x] Update documentation (if necessary)
- [x] Add story to storybook (if necessary)
- [x] Assign dev reviewer
