### PR TITLE
RTL migration: inputs

### DIFF
--- a/test/forms/helpers/replace-empty-string-value.test.js
+++ b/test/forms/helpers/replace-empty-string-value.test.js
@@ -1,27 +1,26 @@
 import { replaceEmptyStringValue } from '../../../src/'
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+
+const InputToWrap = ({ input: { value } }) => (
+  <input value={value} readOnly={true} />
+)
 
 test('has correct displayName', () => {
-  const MyInput = () => <input />
-  const WrappedInput = replaceEmptyStringValue()(MyInput)
-  expect(WrappedInput.displayName).toEqual('replaceEmptyStringValue(MyInput)')
+  const WrappedInput = replaceEmptyStringValue()(InputToWrap)
+  expect(WrappedInput.displayName).toEqual('replaceEmptyStringValue(InputToWrap)')
 })
 
 test('replaces empty string with given value', () => {
-  const MyInput = () => <input />
-  const WrappedInput = replaceEmptyStringValue('foo')(MyInput)
-  const wrapper = mount(
-    <WrappedInput {...{ input: { value: '' }, meta: {} }} />
-  )
-  expect(wrapper.find(MyInput).props().input.value).toEqual('foo')
+  const WrappedInput = replaceEmptyStringValue('foo')(InputToWrap)
+  render(<WrappedInput {...{ input: { value: '' }, meta: {} }} />)
+  expect(screen.getByRole('textbox')).toHaveValue('foo')
 })
 
 test("doesn't replace other values", () => {
-  const MyInput = () => <input />
-  const WrappedInput = replaceEmptyStringValue('foo')(MyInput)
-  const wrapper = mount(
+  const WrappedInput = replaceEmptyStringValue('foo')(InputToWrap)
+  render(
     <WrappedInput {...{ input: { value: 'other' }, meta: {} }} />
   )
-  expect(wrapper.find(MyInput).props().input.value).toEqual('other')
+  expect(screen.getByRole('textbox')).toHaveValue('other')
 })

--- a/test/forms/inputs/cloudinary-file-input/cloudinary-uploader.test.js
+++ b/test/forms/inputs/cloudinary-file-input/cloudinary-uploader.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render } from '@testing-library/react'
 import cloudinaryUploader from '../../../../src/forms/inputs/cloudinary-file-input/cloudinary-uploader'
 
 class MockResponse {
@@ -64,49 +64,50 @@ test('cloudinaryUploader has correct displayName', () => {
 })
 
 test('cloudinaryUploader throws an error if `bucket`, `cloudName`, or `apiAdapter` are not provided', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => null) // avoid console bloat
   const Wrapped = () => <h1>Hi</h1>
   const Wrapper = cloudinaryUploader()(Wrapped)
-  expect(() => shallow(<Wrapper />)).toThrow()
+  expect(() => render(<Wrapper />)).toThrow()
+  jest.restoreAllMocks()
 })
 
 test('cloudinaryUploader can receive arguments via env vars', () => {
+  // eslint-disable-next-line no-undef
   process.env.CLOUDINARY_CLOUD_NAME = 'foo'
+  // eslint-disable-next-line no-undef
   process.env.CLOUDINARY_BUCKET = 'bar'
   const Wrapped = () => <h1>Hi</h1>
   const Wrapper = cloudinaryUploader({ apiAdapter: props.apiAdapter })(Wrapped)
-  expect(() => shallow(<Wrapper />)).not.toThrow()
-})
-
-test('cloudinaryUploader adds upload props to component', () => {
-  const Wrapped = () => <h1>Hi</h1>
-  const Wrapper = cloudinaryUploader(props)(Wrapped)
-  const component = shallow(<Wrapper />)
-  expect(component.props()).toMatchObject({
-    upload: expect.any(Function),
-    uploadStatus: expect.any(String),
-  })
+  expect(() => render(<Wrapper />)).not.toThrow()
 })
 
 test('cloudinaryUploader can receive options as props', () => {
   const Wrapped = () => <h1>Hi</h1>
   const Wrapper = cloudinaryUploader()(Wrapped)
-  const component = shallow(
+  expect(() => render(
     <Wrapper cloudName="foo" bucket="bar" apiAdapter={() => {}} />
-  )
-  expect(component.props()).toMatchObject({
+  )).not.toThrow()
+})
+
+test('cloudinaryUploader adds upload props to component', () => {
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
+  const Wrapper = cloudinaryUploader(props)(Wrapped)
+  render(<Wrapper />)
+  expect(Wrapped).toHaveBeenCalledWith(expect.objectContaining({
     upload: expect.any(Function),
     uploadStatus: expect.any(String),
-  })
+  }), {})
 })
 
 test('cloudinaryUploader sends the api request with the correct options', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const Wrapper = cloudinaryUploader(props)(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+
+  const { upload } = Wrapped.mock.calls[0][0]
+
   return upload(fileData, file).then((response) => {
-    component.update()
-    const { uploadStatus } = component.props()
+    const { uploadStatus } = Wrapped.mock.calls[2][0]
     expect(uploadStatus).toEqual('upload-success')
     const responseJson = JSON.parse(response.body)
     expect(responseJson.file).toEqual(fileData)
@@ -117,45 +118,45 @@ test('cloudinaryUploader sends the api request with the correct options', () => 
 })
 
 test('cloudinaryUploader sets `publicId`', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const Wrapper = cloudinaryUploader({
     ...props,
     cloudinaryPublicId: 'custom-name',
   })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+
   return upload(fileData, file).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('custom-name')
   })
 })
 
 test('cloudinaryUploader allows custom `publicId` creator', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const createPublicId = (file) => 'foo-' + file.name
   const Wrapper = cloudinaryUploader({ ...props, createPublicId })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+
   return upload(fileData, file).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('foo-test')
   })
 })
 
 test('cloudinaryUploader overrides custom `publicId` creator with `cloudinaryPublicId`', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const createPublicId = (file) => 'foo-' + file.name
   const Wrapper = cloudinaryUploader({
     ...props,
     createPublicId,
     cloudinaryPublicId: 'custom-name',
   })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+
   return upload(fileData, file).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('custom-name')
   })
@@ -163,15 +164,15 @@ test('cloudinaryUploader overrides custom `publicId` creator with `cloudinaryPub
 
 test('cloudinaryUploader adds extension to `publicId` of raw files', () => {
   const rawFile = { name: 'test.xls', type: 'application/xls' }
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const Wrapper = cloudinaryUploader({
     ...props,
     cloudinaryPublicId: 'custom-name',
   })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+
   return upload(fileData, rawFile).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('custom-name.xls')
   })
@@ -183,13 +184,13 @@ test('cloudinaryUploader removes invalid characters from the default `publicId`'
     name: 'Final \\ Master %20 Schedule? #S1&S2 <100%> & finished.pdf',
     type: 'application/pdf',
   }
-  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapped = jest.fn(() => <h1>Howdy</h1>)
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+
 
   return upload(fileData, illegallyNamedFile).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).not.toMatch(FORBIDDEN_PATTERN)
   })
@@ -200,13 +201,12 @@ test('cloudinaryUploader removes html escaped characters from the default `publi
     name: 'SY%20S1%26S2.pdf',
     type: 'application/pdf',
   }
-  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapped = jest.fn(() => <h1>Howdy</h1>)
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
 
   return upload(fileData, illegallyNamedFile).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('SY_S1_S2')
   })
@@ -217,13 +217,12 @@ test('cloudinaryUploader replaces spaces and removes superfluous underscores fro
     name: '     SY     S1___S2.pdf',
     type: 'application/pdf',
   }
-  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapped = jest.fn(() => <h1>Howdy</h1>)
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
 
   return upload(fileData, illegallyNamedFile).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('SY_S1_S2')
   })
@@ -234,13 +233,12 @@ test('cloudinaryUploader trims spaces from the start of the default `publicId`',
     name: '     Example.pdf',
     type: 'application/pdf',
   }
-  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapped = jest.fn(() => <h1>Howdy</h1>)
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
 
   return upload(fileData, illegallyNamedFile).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('Example')
   })
@@ -248,15 +246,14 @@ test('cloudinaryUploader trims spaces from the start of the default `publicId`',
 
 test('cloudinaryUploader defaults file name if not provided when creating the default `publicId`', () => {
   const fileWithNoName = { name: '', type: 'application/pdf' }
-  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapped = jest.fn(() => <h1>Howdy</h1>)
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
-
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
+  // eslint-disable-next-line no-undef
   const spy = jest.spyOn(global.Date, 'now')
 
   return upload(fileData, fileWithNoName).then((response) => {
-    component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toContain('file_upload')
     expect(spy).toHaveBeenCalled()
@@ -266,12 +263,12 @@ test('cloudinaryUploader defaults file name if not provided when creating the de
 })
 
 test('cloudinaryUploader throws an error if request fails', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const Wrapper = cloudinaryUploader({ ...props, endpoint: '/failure' })(
     Wrapped
   )
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
 
   expect.assertions(1)
 
@@ -279,17 +276,16 @@ test('cloudinaryUploader throws an error if request fails', () => {
 })
 
 test('cloudinaryUploader updates the `uploadStatus` prop if request fails', () => {
-  const Wrapped = () => <h1>Hi</h1>
+  const Wrapped = jest.fn(() => <h1>Hi</h1>)
   const Wrapper = cloudinaryUploader({ ...props, endpoint: '/failure' })(
     Wrapped
   )
-  const component = shallow(<Wrapper />)
-  const { upload } = component.props()
+  render(<Wrapper />)
+  const { upload } = Wrapped.mock.calls[0][0]
 
   expect.assertions(1)
   return upload(fileData, file).catch(() => {
-    component.update()
-    const { uploadStatus } = component.props()
+    const { uploadStatus } = Wrapped.mock.calls[2][0]
     expect(uploadStatus).toEqual('upload-failure')
   })
 })

--- a/test/forms/inputs/icon-input.test.js
+++ b/test/forms/inputs/icon-input.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { mount } from 'enzyme'
 import { IconInput } from '../../../src/'
 import { render, screen } from '@testing-library/react'
 

--- a/test/forms/inputs/input.test.js
+++ b/test/forms/inputs/input.test.js
@@ -39,13 +39,13 @@ test('Input is given an aria-describedby attribute when there is an input error'
 test('Input id defaults to name when no id is provided', () => {
   const props = { input, meta: {} }
   render(<Input {...props} />)
-  expect(screen.getByLabelText('Field')).toHaveAttribute('id', 'name')
+  expect(screen.getByLabelText('Field')).toHaveAttribute('id', name)
 })
 
 test('Input id is set when id is provided', () => {
   const props = { input, meta: {} }
   render(<Input {...props} id="testId" />)
-  expect(screen.getByLabelText('Field').id).toBe('testId')
+  expect(screen.getByLabelText('Field')).toHaveAttribute('id', 'testId')
 })
 
 test('Input does not receive invalid dom attributes', () => {

--- a/test/forms/inputs/input.test.js
+++ b/test/forms/inputs/input.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import { Input } from '../../../src/'
 
 const name = 'name.of.field'
@@ -9,43 +9,43 @@ const input = { name, value, onChange }
 
 test('Input defaults to text input', () => {
   const props = { input, meta: {} }
-  const wrapper = mount(<Input {...props} />)
-  expect(wrapper.find('input').prop('type')).toEqual('text')
+  render(<Input {...props} />)
+  expect(screen.getByLabelText('Field')).toHaveAttribute('type', 'text')
 })
 
 test('Input contains div with class input-wrapper', () => {
   const props = { input, meta: {} }
-  const wrapper = mount(<Input {...props} />)
-  expect(wrapper.find('div.input-wrapper').exists()).toEqual(true)
+  render(<Input {...props} />)
+  expect(screen.getByLabelText('Field').parentElement).toHaveClass('input-wrapper')
 })
 
 test('Input renders children', () => {
   const Wrapped = () => <p> I'm a child component </p>
   const props = { input, meta: {} }
-  const wrapper = mount(
+  render(
     <Input {...props}>
       <Wrapped />
     </Input>
   )
-  expect(wrapper.find(Wrapped).exists()).toEqual(true)
+  expect(screen.getByText("I'm a child component")).toBeInTheDocument()
 })
 
 test('Input is given an aria-describedby attribute when there is an input error', () => {
   const props = { input, meta: { touched: true, invalid: true } }
-  const wrapper = mount(<Input {...props} />)
-  expect(wrapper.find('input').prop('aria-describedby')).toContain(name)
+  render(<Input {...props} />)
+  expect(screen.getByLabelText('Field').getAttribute('aria-describedby')).toContain(name)
 })
 
 test('Input id defaults to name when no id is provided', () => {
   const props = { input, meta: {} }
-  const wrapper = mount(<Input {...props} />)
-  expect(wrapper.find('input').prop('id')).toBe(name)
+  render(<Input {...props} />)
+  expect(screen.getByLabelText('Field').id).toBe(name)
 })
 
 test('Input id is set when id is provided', () => {
   const props = { input, meta: {} }
-  const wrapper = mount(<Input {...props} id="testId" />)
-  expect(wrapper.find('input').prop('id')).toBe('testId')
+  render(<Input {...props} id="testId" />)
+  expect(screen.getByLabelText('Field').id).toBe('testId')
 })
 
 test('Input does not receive invalid dom attributes', () => {
@@ -55,6 +55,6 @@ test('Input does not receive invalid dom attributes', () => {
     onClickLabel: () => 'foo',
   }
 
-  const wrapper = mount(<Input {...props} />)
-  expect(wrapper.find('input').prop('onClickLabel')).toBe(undefined)
+  render(<Input {...props} />)
+  expect(screen.getByLabelText('Field')).not.toHaveAttribute('onClickLabel')
 })

--- a/test/forms/inputs/input.test.js
+++ b/test/forms/inputs/input.test.js
@@ -39,7 +39,7 @@ test('Input is given an aria-describedby attribute when there is an input error'
 test('Input id defaults to name when no id is provided', () => {
   const props = { input, meta: {} }
   render(<Input {...props} />)
-  expect(screen.getByLabelText('Field').id).toBe(name)
+  expect(screen.getByLabelText('Field')).toHaveAttribute('id', 'name')
 })
 
 test('Input id is set when id is provided', () => {

--- a/test/forms/inputs/masked-input.test.js
+++ b/test/forms/inputs/masked-input.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MaskedInput } from '../../../src'
 
 const name = 'name.of.field'
@@ -7,32 +8,34 @@ const value = 'value of field'
 const onChange = () => {}
 const input = { name, value, onChange }
 
-test('MaskedInput applies comma-separated number mask', () => {
-  const wrapper = mount(
+test('MaskedInput applies comma-separated number mask', async () => {
+  const user = userEvent.setup()
+  render(
     <MaskedInput input={input} meta={{}} maskOptions={{ numeral: true }} />
   )
-  wrapper.find('input').simulate('change', { target: { value: '1234' } })
-  const inputValue = wrapper.find('input').prop('value')
-  expect(inputValue.includes(',')).toBe(true)
+  const maskedInput = screen.getByRole('textbox')
+  maskedInput.focus()
+  await user.keyboard('1234')
+  expect(maskedInput.value).toContain(',')
 })
 
 test('MaskedInput accepts forwarded ref attribute', () => {
   const ref = React.createRef()
-  const wrapper = mount(<MaskedInput input={input} meta={{}} htmlRef={ref} />)
-  expect(wrapper.find('input').prop('id')).toEqual(ref.current.id)
+  render(<MaskedInput input={input} meta={{}} htmlRef={ref} />)
+  expect(screen.getByRole('textbox')).toHaveAttribute('id', ref.current.id)
 })
 
 test('MaskedInput accepts forwarded callback ref', () => {
   const ref = React.createRef()
   const callbackRef = (el) => (ref.current = el)
-  const wrapper = mount(
+  render(
     <MaskedInput input={input} meta={{}} htmlRef={callbackRef} />
   )
-  expect(wrapper.find('input').prop('id')).toEqual(ref.current.id)
+  expect(screen.getByRole('textbox')).toHaveAttribute('id', ref.current.id)
 })
 
 test('MaskedInput triggers onInit handler', () => {
   const onInit = jest.fn()
-  mount(<MaskedInput input={input} meta={{}} onInit={onInit} />)
+  render(<MaskedInput input={input} meta={{}} onInit={onInit} />)
   expect(onInit).toHaveBeenCalledTimes(1)
 })

--- a/test/forms/inputs/masked-input.test.js
+++ b/test/forms/inputs/masked-input.test.js
@@ -16,7 +16,7 @@ test('MaskedInput applies comma-separated number mask', async () => {
   const maskedInput = screen.getByRole('textbox')
   maskedInput.focus()
   await user.keyboard('1234')
-  expect(maskedInput.value).toContain(',')
+  expect(maskedInput.value).toEqual('1,234')
 })
 
 test('MaskedInput accepts forwarded ref attribute', () => {

--- a/test/forms/inputs/radio-group.test.js
+++ b/test/forms/inputs/radio-group.test.js
@@ -1,8 +1,10 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { RadioGroup } from '../../../src/'
 
-test('RadioGroup changes value when buttons are clicked', () => {
+test('RadioGroup changes value when buttons are clicked', async () => {
+  const user = userEvent.setup()
   const onChange = jest.fn()
   const props = {
     input: {
@@ -13,10 +15,11 @@ test('RadioGroup changes value when buttons are clicked', () => {
     meta: {},
     options: ['Option 1', 'Option 2'],
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  wrapper.find('input').first().simulate('change')
+  render(<RadioGroup {...props} />)
+  const radioOptions = screen.getAllByRole('radio')
+  await user.click(radioOptions.at(0))
   expect(onChange).toHaveBeenCalledWith('Option 1')
-  wrapper.find('input').last().simulate('change')
+  await user.click(radioOptions.at(1))
   expect(onChange).toHaveBeenCalledWith('Option 2')
 })
 
@@ -30,26 +33,28 @@ test("RadioGroup's inputs all have the same name", () => {
     meta: {},
     options: ['Option 1', 'Option 2'],
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  expect(wrapper.find('input').first().prop('name')).toEqual(name)
-  expect(wrapper.find('input').last().prop('name')).toEqual(name)
+  render(<RadioGroup {...props} />)
+  const radioOptions = screen.getAllByRole('radio')
+  expect(radioOptions.at(0)).toHaveAttribute('name', name)
+  expect(radioOptions.at(1)).toHaveAttribute('name', name)
 })
 
 test("RadioGroup input has a value that matches the corresponding option's value", () => {
+  const options = ['Option 1', 'Option 2']
   const props = {
     input: {
       name: 'test',
       value: '',
     },
     meta: {},
-    options: ['Option 1', 'Option 2'],
+    options,
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  expect(wrapper.find('input').first().prop('value')).toEqual('Option 1')
-  expect(wrapper.find('input').last().prop('value')).toEqual('Option 2')
+  render(<RadioGroup {...props} />)
+  expect(screen.getByRole('radio', { name: options.at(0) })).toHaveAttribute('value', options.at(0))
+  expect(screen.getByRole('radio', { name: options.at(1) })).toHaveAttribute('value', options.at(1))
 })
 
-test("RadioGroup has a legend with the group's name by default", () => {
+test("RadioGroup has a legend with the input's name start-cased by default", () => {
   const name = 'sameName'
   const props = {
     input: {
@@ -59,10 +64,8 @@ test("RadioGroup has a legend with the group's name by default", () => {
     meta: {},
     options: ['Option 1', 'Option 2'],
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  const legend = wrapper.find('fieldset').first().find('legend')
-  expect(legend).toBeTruthy()
-  expect(legend.text()).toEqual('Same Name')
+  render(<RadioGroup {...props} />)
+  expect(screen.getByRole('group', { name: 'Same Name' })).toBeInTheDocument()
 })
 
 test("RadioGroup has a legend with the group's label (when provided)", () => {
@@ -76,42 +79,40 @@ test("RadioGroup has a legend with the group's label (when provided)", () => {
     label: 'Different Name',
     options: ['Option 1', 'Option 2'],
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  const legend = wrapper.find('fieldset').first().find('legend')
-  expect(legend).toBeTruthy()
-  expect(legend.text()).toEqual('Different Name')
+  render(<RadioGroup {...props} />)
+  expect(screen.getByRole('group', { name: 'Different Name' })).toBeInTheDocument()
 })
 
 test('RadioGroup does not pass down class name', () => {
-  const onChange = jest.fn()
   const props = {
     input: {
       name: 'test',
       value: '',
-      onChange,
     },
     meta: {},
-    options: ['Option 1', 'Option 2'],
+    options: ['Option 1'],
     className: 'custom-radio',
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  expect(wrapper.find('.custom-radio').hostNodes().length).toEqual(1)
+  render(<RadioGroup {...props} />)
+  expect(screen.getByRole('group', { name: 'Test' })).toHaveClass('custom-radio')
+  expect(screen.getByRole('radio')).not.toHaveClass('custom-radio')
 })
 
 test('RadioGroup passes down props to children', () => {
-  const onChange = jest.fn()
   const props = {
     input: {
       name: 'test',
       value: '',
-      onChange,
     },
     meta: {},
     options: ['Option 1', 'Option 2'],
     className: 'custom-radio-group',
+    'data-test': 'true',
     radioInputProps: { className: 'custom-radio-input' },
   }
-  const wrapper = mount(<RadioGroup {...props} />)
-  expect(wrapper.find('input.custom-radio-group').exists()).toBe(false)
-  expect(wrapper.find('input.custom-radio-input').exists()).toBe(true)
+  render(<RadioGroup {...props} />)
+  screen.getAllByRole('radio').forEach((el) => {
+    expect(el).toHaveClass('custom-radio-input')
+    expect(el).toHaveAttribute('data-test', 'true')
+  })
 })

--- a/test/forms/inputs/range-input.test.js
+++ b/test/forms/inputs/range-input.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import { RangeInput } from '../../../src/'
 
 const name = 'name.of.field'
@@ -9,22 +9,29 @@ const input = { name, value, onChange }
 
 test('RangeInput hides the value label when `hideRangeValue` is `true`', () => {
   const props = { input, hideRangeValue: true, meta: {} }
-  const wrapper = mount(<RangeInput {...props} />)
-  expect(wrapper.find('.range-value').exists()).toBe(false)
+  render(<RangeInput {...props} />)
+  expect(screen.queryByText(input.value)).not.toBeInTheDocument()
+})
+
+test('RangeInput shows the value label when `hideRangeValue` is `false`', () => {
+  const props = { input, hideRangeValue: false, meta: {} }
+  render(<RangeInput {...props} />)
+  expect(screen.queryByText(input.value)).toBeInTheDocument()
 })
 
 test('RangeInput sets the `min`, `max`, and `step` correctly', () => {
   const props = { input, min: 5, max: 50, step: 10, meta: {} }
-  const wrapper = mount(<RangeInput {...props} />)
-  expect(wrapper.find('input').props().min).toEqual(5)
-  expect(wrapper.find('input').props().max).toEqual(50)
-  expect(wrapper.find('input').props().step).toEqual(10)
+  render(<RangeInput {...props} />)
+  const rangeInput = screen.getByLabelText('Field')
+  expect(rangeInput.getAttribute('min')).toEqual('5')
+  expect(rangeInput.getAttribute('max')).toEqual('50')
+  expect(rangeInput.getAttribute('step')).toEqual('10')
 })
 
 test('RangeInput has aria-describedby attribute when there is an input error', () => {
   const props = { input, meta: { touched: true, invalid: true } }
-  const wrapper = mount(<RangeInput {...props} />)
-  expect(wrapper.find('input').prop('aria-describedby')).toContain(name)
+  render(<RangeInput {...props} />)
+  expect(screen.getByLabelText('Field').getAttribute('aria-describedby')).toContain(name)
 })
 
 test('RangeInput does not receive invalid dom attributes', () => {
@@ -34,6 +41,6 @@ test('RangeInput does not receive invalid dom attributes', () => {
     onClickLabel: () => 'foo',
   }
 
-  const wrapper = mount(<RangeInput {...props} />)
-  expect(wrapper.find('input').prop('onClickLabel')).toBe(undefined)
+  render(<RangeInput {...props} />)
+  expect(screen.getByLabelText('Field')).not.toHaveAttribute('onClickLabel')
 })

--- a/test/forms/inputs/select.test.js
+++ b/test/forms/inputs/select.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import { within } from '@testing-library/dom'
 import { Select } from '../../../src/'
 
 const DEFAULT_PLACEHOLDER = 'Select'
@@ -17,9 +18,8 @@ test('Select adds string options to select tag', () => {
     options: [OPTION],
     placeholder: '',
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('option').contains(OPTION)).toEqual(true)
-  expect(wrapper.find('option').prop('value')).toEqual(OPTION)
+  render(<Select {...props} />)
+  expect(screen.getByRole('option')).toHaveValue(OPTION)
 })
 
 test('Select adds object options to select tag', () => {
@@ -35,9 +35,8 @@ test('Select adds object options to select tag', () => {
     options: [{ key: KEY, value: VALUE }],
     placeholder: '',
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('option').contains(KEY)).toEqual(true)
-  expect(wrapper.find('option').prop('value')).toEqual(VALUE)
+  render(<Select {...props} />)
+  expect(screen.getByRole('option', { name: KEY })).toHaveValue(VALUE)
 })
 
 test('Select adds placeholder option to select tag', () => {
@@ -52,9 +51,8 @@ test('Select adds placeholder option to select tag', () => {
     options: [],
     placeholder: PLACEHOLDER,
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('option').contains(PLACEHOLDER)).toEqual(true)
-  expect(wrapper.find('option').prop('value')).toEqual('')
+  render(<Select {...props} />)
+  expect(screen.getByRole('option', { name: PLACEHOLDER })).toHaveValue('')
 })
 
 test('Select enables the placeholder option to be selected correctly', () => {
@@ -70,9 +68,22 @@ test('Select enables the placeholder option to be selected correctly', () => {
     placeholder: PLACEHOLDER,
     enablePlaceholderOption: true,
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('option').first().prop('value')).toEqual('')
-  expect(wrapper.find('option').first().prop('disabled')).toEqual(false)
+  render(<Select {...props} />)
+  expect(screen.getByRole('option', { name: PLACEHOLDER })).toBeEnabled()
+})
+
+test('Select has a disabled placeholder by default', () => {
+  const props = {
+    input: {
+      name: 'test',
+      value: '',
+      onChange,
+    },
+    options: [],
+    meta: {},
+  }
+  render(<Select {...props} />)
+  expect(screen.getByRole('option', { name: DEFAULT_PLACEHOLDER })).toBeDisabled()
 })
 
 test('Select renders option groups correctly', () => {
@@ -87,24 +98,9 @@ test('Select renders option groups correctly', () => {
     optionGroups: [options],
     placeholder: '',
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('optgroup').first().prop('label')).toEqual('groupName')
-  expect(wrapper.find('option').first().prop('value')).toEqual('testOption')
-})
-
-test('Select has a placeholder by default', () => {
-  const props = {
-    input: {
-      name: 'test',
-      value: '',
-      onChange,
-    },
-    options: [],
-    meta: {},
-  }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('option').contains(DEFAULT_PLACEHOLDER)).toEqual(true)
-  expect(wrapper.find('option').prop('value')).toEqual('')
+  render(<Select {...props} />)
+  const optionGroup = screen.getByRole('group', { name: options.name })
+  expect(within(optionGroup).getByRole('option', { name: 'testOption'})).toBeInTheDocument()
 })
 
 test('Select adds an aria-describedby attribute when there is an input error', () => {
@@ -122,8 +118,8 @@ test('Select adds an aria-describedby attribute when there is an input error', (
     },
     options: [OPTION],
   }
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('select').prop('aria-describedby')).toContain(name)
+  render(<Select {...props} />)
+  expect(screen.getByRole('combobox').getAttribute('aria-describedby')).toContain(name)
 })
 
 test('Select does not receive invalid dom attributes', () => {
@@ -140,6 +136,6 @@ test('Select does not receive invalid dom attributes', () => {
     onClickLabel: () => 'foo',
   }
 
-  const wrapper = mount(<Select {...props} />)
-  expect(wrapper.find('select').prop('onClickLabel')).toBe(undefined)
+  render(<Select {...props} />)
+  expect(screen.getByRole('combobox')).not.toHaveAttribute('onClickLabel')
 })

--- a/test/forms/inputs/switch.test.js
+++ b/test/forms/inputs/switch.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { mount } from 'enzyme'
 import { Switch } from '../../../src'
 
 test('Switch toggles value when clicked', async () => {

--- a/test/forms/inputs/switch.test.js
+++ b/test/forms/inputs/switch.test.js
@@ -1,9 +1,12 @@
 import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { mount } from 'enzyme'
 import { Switch } from '../../../src'
 
-test('Switch toggles value when clicked', () => {
+test('Switch toggles value when clicked', async () => {
   const onChange = jest.fn()
+  const user = userEvent.setup()
   const props = {
     input: {
       name: 'test',
@@ -12,8 +15,8 @@ test('Switch toggles value when clicked', () => {
     },
     meta: {},
   }
-  const wrapper = mount(<Switch {...props} />)
-  wrapper.find('input').simulate('change')
+  render(<Switch {...props} />)
+  await user.click(screen.getByLabelText('Test'))
   const newValue = onChange.mock.calls[0][0]
   expect(newValue).toEqual(true)
 })
@@ -30,6 +33,6 @@ test('Switch is given an aria-describedby attribute when there is an input error
       invalid: true,
     },
   }
-  const wrapper = mount(<Switch {...props} />)
-  expect(wrapper.find('input').prop('aria-describedby')).toContain(name)
+  render(<Switch {...props} />)
+  expect(screen.getByLabelText('Test').getAttribute('aria-describedby')).toContain(name)
 })

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import { Textarea } from '../../../src/'
 
 const onChange = () => {}
@@ -13,9 +13,10 @@ test('Textarea passes down defaults and does not show character count', () => {
     },
     meta: {},
   }
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('maxLength')).toEqual(null)
-  expect(wrapper.find('.character-count').exists()).toEqual(false)
+  render(<Textarea {...props} />)
+  const textarea = screen.getByLabelText('Test')
+  expect(textarea).not.toHaveAttribute('maxLength')
+  expect(textarea.previousSibling).not.toHaveClass('character-count')
 })
 
 test('Textarea passes down max length and shows character count correctly', () => {
@@ -28,9 +29,9 @@ test('Textarea passes down max length and shows character count correctly', () =
     meta: {},
     maxLength: 5,
   }
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('maxLength')).toEqual(5)
-  expect(wrapper.find('.character-count').exists()).toEqual(true)
+  render(<Textarea {...props} />)
+  expect(screen.getByLabelText('Test')).toHaveAttribute('maxLength', '5')
+  expect(screen.getByText('0/5 characters'))
 })
 
 test('Textarea hides character count correctly', () => {
@@ -44,9 +45,9 @@ test('Textarea hides character count correctly', () => {
     maxLength: 5,
     hideCharacterCount: true,
   }
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('maxLength')).toEqual(5)
-  expect(wrapper.find('.character-count').exists()).toEqual(false)
+  render(<Textarea {...props} />)
+  expect(screen.getByLabelText('Test')).toHaveAttribute('maxLength', '5')
+  expect(screen.queryByText('0/5 characters')).not.toBeInTheDocument()
 })
 
 test('Textarea is given an aria-describedby attribute when there is an input error', () => {
@@ -64,8 +65,8 @@ test('Textarea is given an aria-describedby attribute when there is an input err
     maxLength: 5,
     hideCharacterCount: true,
   }
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('aria-describedby')).toContain(name)
+  render(<Textarea {...props} />)
+  expect(screen.getByLabelText('Test').getAttribute('aria-describedby')).toContain(name)
 })
 
 test('Textarea does not receive invalid dom attributes', () => {
@@ -82,8 +83,8 @@ test('Textarea does not receive invalid dom attributes', () => {
     onClickLabel: () => 'foo',
   }
 
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('onClickLabel')).toBe(undefined)
+  render(<Textarea {...props} />)
+  expect(screen.getByLabelText('Test')).not.toHaveAttribute('onClickLabel')
 })
 
 test('Textarea passes down forwardedRef to input correctly', () => {
@@ -98,6 +99,6 @@ test('Textarea passes down forwardedRef to input correctly', () => {
     forwardedRef: inputRef,
   }
 
-  const wrapper = mount(<Textarea {...props} />)
-  expect(wrapper.find('textarea').prop('id')).toEqual(inputRef.current.id)
+  render(<Textarea {...props} />)
+  expect(screen.getByLabelText('Test').id).toEqual(inputRef.current.id)
 })

--- a/test/forms/inputs/textarea.test.js
+++ b/test/forms/inputs/textarea.test.js
@@ -100,5 +100,5 @@ test('Textarea passes down forwardedRef to input correctly', () => {
   }
 
   render(<Textarea {...props} />)
-  expect(screen.getByLabelText('Test').id).toEqual(inputRef.current.id)
+  expect(screen.getByLabelText('Test')).toHaveAttribute('id', inputRef.current.id)
 })


### PR DESCRIPTION
Ports over the remaining files in `test/forms/inputs` to use RTL
## Author Checklist

- [x] Add unit test(s)
- [ ] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [ ] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [x] Assign dev reviewer
