### PR TITLE
Fix flaky aria-disabled tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "engines": {
     "node": "^18.12"
   },

--- a/test/forms/buttons/button.test.js
+++ b/test/forms/buttons/button.test.js
@@ -7,14 +7,14 @@ test('Button is aria-disabled when form is invalid', () => {
   render(<Button invalid={true}>Hi</Button>)
   const button = screen.getByRole('button')
 
-  expect(button).toHaveAttribute('aria-disabled')
+  expect(button).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('Button is aria-disabled when form is pristine', () => {
   render(<Button pristine={true}>Hi</Button>)
   const button = screen.getByRole('button')
 
-  expect(button).toHaveAttribute('aria-disabled')
+  expect(button).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('Button onClick is run when the form is not submitting, pristine, or invalid', async () => {


### PR DESCRIPTION
<!-- Include description and link to resolved issue(s) here. -->
@chawes13 found a flaky test when reviewing the [RTL Cheat Sheet](https://www.notion.so/launchpadlab/React-Testing-Library-RTL-Cheatsheet-82af6c02b19f4a9eb5cde8f64901a4d0?pvs=4).

We were only checking for the existence of the `aria-disabled` attribute but not its value. If `aria-disabled` were `false`, the test would still pass, and that's not the desired outcome.

## Release Notes
<!-- Optional description of the resolved issue(s) that will be included in the -->
<!-- GitHub release description of this library. -->

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [x] Update documentation (if necessary)
- [x] Add story to storybook (if necessary)
- [x] Assign dev reviewer
