### PR TITLE
Allow Class Specification on TableColumn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-components",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "engines": {
     "node": "^18.12 || ^20.0"
   },

--- a/src/tables/components/table-header.js
+++ b/src/tables/components/table-header.js
@@ -12,7 +12,7 @@ const propTypes = {
 }
 
 function TableHeader({
-  column: { name, label, disabled },
+  column: { className, name, label, disabled },
   sortPath,
   ascending,
   onClick,
@@ -22,7 +22,7 @@ function TableHeader({
   return (
     <th
       onClick={onClick}
-      className={classnames(arrowClass, { sortable: !disabled })}
+      className={classnames(arrowClass, { sortable: !disabled }, className)}
     >
       {label || startCase(name)}
     </th>

--- a/test/tables/sortable-table.test.js
+++ b/test/tables/sortable-table.test.js
@@ -476,4 +476,15 @@ describe('SortableTable', () => {
     )
     expect(screen.getByText('My Table')).toHaveClass('custom-caption')
   })
+
+  test('Column with custom className is propagated to TableHeader', () => {
+    render(
+      <SortableTable data={tableData}>
+        <Column name="name" className="foo" />
+      </SortableTable>
+    )
+
+    const header = screen.getByText('Name').closest('th')
+    expect(header).toHaveClass('foo')
+  })
 })


### PR DESCRIPTION
<!-- Include description and link to resolved issue(s) here. -->
This is in reference to an [enhancement](https://github.com/LaunchPadLab/lp-components/issues/633) to add to a `Table` and pass a custom classname. 

## Release Notes
<!-- Optional description of the resolved issue(s) that will be included in the -->
<!-- GitHub release description of this library. -->

## Author Checklist

- [x] Add unit test(s)
- [x] Update version in package.json (see the [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/main/gists/npm-package-guidelines.md#pull-requests-and-deployments))
- [ ] Update documentation (if necessary)
- [ ] Add story to storybook (if necessary)
- [x] Assign dev reviewer
